### PR TITLE
fix: update the status of geo-replication destination connection

### DIFF
--- a/pkg/connection/reconcile_geo_replication.go
+++ b/pkg/connection/reconcile_geo_replication.go
@@ -208,6 +208,12 @@ func (r *PulsarGeoReplicationReconciler) ReconcileGeoReplication(ctx context.Con
 		}
 	}
 
+	destConnection.Status.ObservedGeneration = destConnection.Generation
+	meta.SetStatusCondition(&destConnection.Status.Conditions, *NewReadyCondition(destConnection.Generation))
+	if err := r.conn.client.Status().Update(ctx, destConnection); err != nil {
+		return err
+	}
+
 	geoReplication.Status.ObservedGeneration = geoReplication.Generation
 	meta.SetStatusCondition(&geoReplication.Status.Conditions, *NewReadyCondition(geoReplication.Generation))
 	if err := r.conn.client.Status().Update(ctx, geoReplication); err != nil {


### PR DESCRIPTION
<!--
### Contribution Checklist

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.

**(The sections below can be removed for hotfixes of typos)**
-->

Fixes #118 

Master Issue: #<xyz>

### Motivation

The status of the  pulsarconnection  which is used for geo-replication destination connection is not updated.

### Modifications

- Update the status of the pulsar connection which is used for indicating the geo-replication destination connection after the PulsarGeoReplication is created successfully.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

Check the box below.

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)

