### PR TITLE
fix: cluster info will be reset when updating geo-replication object

### DIFF
--- a/pkg/admin/impl.go
+++ b/pkg/admin/impl.go
@@ -611,6 +611,8 @@ func (p *PulsarAdminClient) UpdateCluster(name string, param *ClusterParams) err
 	if param.ServiceSecureURL != "" && param.BrokerServiceSecureURL != "" {
 		clusterData.ServiceURLTls = param.ServiceSecureURL
 		clusterData.BrokerServiceURLTls = param.BrokerServiceSecureURL
+		clusterData.BrokerClientTrustCertsFilePath = param.BrokerClientTrustCertsFilePath
+		clusterData.BrokerClientTLSEnabled = true
 	} else if param.ServiceURL != "" && param.BrokerServiceURL != "" {
 		clusterData.ServiceURL = param.ServiceURL
 		clusterData.BrokerServiceURL = param.BrokerServiceURL


### PR DESCRIPTION
<!--
### Contribution Checklist

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.

**(The sections below can be removed for hotfixes of typos)**
-->

Fixes #131 

### Motivation

Fix the bug that the fields `brokerClientTlsEnabled` and `brokerClientTrustCertsFilePath` of `cluster` will be reset when updating geo-replication object.

### Modifications

Fix the issue.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

Check the box below.

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)

