### PR TITLE
fix: pulsar-connection tls issue

### DIFF
--- a/pkg/connection/reconciler.go
+++ b/pkg/connection/reconciler.go
@@ -109,6 +109,10 @@ func (r *PulsarConnectionReconciler) Reconcile(ctx context.Context) error {
 		return nil
 	}
 
+	if r.connection.Spec.AdminServiceURL == "" && r.connection.Spec.AdminServiceSecureURL != "" {
+		r.connection.Spec.AdminServiceURL = r.connection.Spec.AdminServiceSecureURL
+	}
+
 	// TODO use otelcontroller until kube-instrumentation upgrade controller-runtime version to newer
 	controllerutil.AddFinalizer(r.connection, resourcev1alpha1.FinalizerName)
 	if err := r.client.Update(ctx, r.connection); err != nil {


### PR DESCRIPTION
…r is empty and the later is not


<!--
### Contribution Checklist

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.

**(The sections below can be removed for hotfixes of typos)**
-->

*(If this PR fixes a github issue, please add `Fixes #<xyz>`.)*

Fixes #138 

### Motivation

When the field `adminServiceURL` of `PulsarConnection` is empty, it will not satisfy the URL regex `^https?://.+$`.

### Modifications

Assign the field `adminServiceURL` with the value of the field `adminServiceSecureURL` when the former is empty and the latter is not.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

Check the box below.

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)

