### PR TITLE
fix: change the default lifecyclePolicy to CleanUpAfterDeletion

### DIFF
--- a/docs/pulsar_geo_replication.md
+++ b/docs/pulsar_geo_replication.md
@@ -30,7 +30,7 @@ This table lists specifications available for the `PulsarGeoReplication ` resour
 | ---| --- |--- |
 | `connectionRef` | The reference to a PulsarConnection. | Yes |
 | `destinationConnectionRef` | The reference to a destination PulsarConnection. | Yes |
-| `lifecyclePolicy` | The resource lifecycle policy. Available options are `CleanUpAfterDeletion` and `KeepAfterDeletion`. By default, it is set to `KeepAfterDeletion`. | Optional |
+| `lifecyclePolicy` | The resource lifecycle policy. Available options are `CleanUpAfterDeletion` and `KeepAfterDeletion`. By default, it is set to `CleanUpAfterDeletion`. | Optional |
 
 
 ## How to configure Geo-replication

--- a/docs/pulsar_namespace.md
+++ b/docs/pulsar_namespace.md
@@ -43,7 +43,7 @@ This table lists specifications available for the `PulsarNamespace` resource.
 | `maxConsumersPerSubscription` | The maximum number of consumers per subscription for a namespace. | Optional |
 | `retentionTime` | The retention time (valid time units are "s", "m", "h", "d", "w"). | Optional |
 | `retentionSize` | The retention size limit(such as 800Mi, 10Gi). | Optional |
-| `lifecyclePolicy` | The resource lifecycle policy, CleanUpAfterDeletion or KeepAfterDeletion, the default is KeepAfterDeletion | Optional |
+| `lifecyclePolicy` | The resource lifecycle policy. Available options are `CleanUpAfterDeletion` and `KeepAfterDeletion`. By default, it is set to `CleanUpAfterDeletion`. | Optional |
 | `geoReplicationRefs` | The reference list of the PulsarGeoReplication. Enable Geo-replication at the namespace level. It will add the namespace to the clusters. | No |
 
 

--- a/docs/pulsar_permission.md
+++ b/docs/pulsar_permission.md
@@ -33,7 +33,7 @@ This table lists specifications available for the `PulsarPermission` resource.
 | `resourceName` | The name of the target resource which will be granted the permissions. | Yes |
 | `roles` | The list of roles which will be granted with the same permissions. | Yes
 | `actions` | The list of actions to be granted. The options include `produce`,`consume`,`functions`, `sinks`, `sources`, `packages`. | Optional |
-| `lifecyclePolicy` | The resource lifecycle policy, CleanUpAfterDeletion or KeepAfterDeletion, the default is KeepAfterDeletion | Optional |
+| `lifecyclePolicy` | The resource lifecycle policy. Available options are `CleanUpAfterDeletion` and `KeepAfterDeletion`. By default, it is set to `CleanUpAfterDeletion`. | Optional |
 
 2. Apply the YAML file to create the permission.
 

--- a/docs/pulsar_tenant.md
+++ b/docs/pulsar_tenant.md
@@ -28,7 +28,7 @@ This table lists specifications available for the `PulsarTenant` resource.
 | `connectionRef` | The reference to a PulsarConnection. | Yes |
 | `adminRoles` | The list of authentication principals allowed to manage the tenant. | Optional |
 | `allowedClusters` | The list of allowed clusters. If no cluster is specified, the tenant will have access to all clusters. If you specify a list of clusters, ensure that these clusters exist.| Optional | 
-| `lifecyclePolicy` | The resource lifecycle policy, CleanUpAfterDeletion or KeepAfterDeletion, the default is KeepAfterDeletion | Optional |
+| `lifecyclePolicy` | The resource lifecycle policy. Available options are `CleanUpAfterDeletion` and `KeepAfterDeletion`. By default, it is set to `CleanUpAfterDeletion`. | Optional |
 | `geoReplicationRefs` | The reference list of the PulsarGeoReplication. It will grant permission to the tenant. | No |
 
 2. Apply the YAML file to create the tenant.

--- a/docs/pulsar_topic.md
+++ b/docs/pulsar_topic.md
@@ -45,7 +45,7 @@ This table lists specifications available for the `PulsarTopic` resource.
 | `backlogQuotaLimitTime` | The Backlog quota time limit (valid time units are "s", "m", "h", "d", "w"). | Optional |
 | `backlogQuotaLimitSize` | The Backlog quota size limit (such as 10Mi, 10Gi). | Optional |
 | `backlogQuotaRetentionPolicy` | The Retention policy to be enforced when the limit is reached. | Optional |
-| `lifecyclePolicy` | The resource lifecycle policy, CleanUpAfterDeletion or KeepAfterDeletion, the default is KeepAfterDeletion | Optional |
+| `lifecyclePolicy` | The resource lifecycle policy. Available options are `CleanUpAfterDeletion` and `KeepAfterDeletion`. By default, it is set to `CleanUpAfterDeletion`. | Optional |
 | `schemaInfo` | The schema of pulsar topic, default is nil. More details you can find in [schemaInfo](#schemainfo) Optional |
 | `geoReplicationRefs` | The reference list of the PulsarGeoReplication. Enable Geo-replication at the topic level. It will add the topic to the clusters. | No |
 

--- a/pkg/connection/reconcile_geo_replication.go
+++ b/pkg/connection/reconcile_geo_replication.go
@@ -128,7 +128,7 @@ func (r *PulsarGeoReplicationReconciler) ReconcileGeoReplication(ctx context.Con
 			}
 		}
 		if !skip {
-			if geoReplication.Spec.LifecyclePolicy == resourcev1alpha1.CleanUpAfterDeletion {
+			if geoReplication.Spec.LifecyclePolicy != resourcev1alpha1.KeepAfterDeletion {
 				// Delete the cluster that created with destination cluster info.
 				// TODO it can only be deleted after the cluster has been removed from the tenant, namespace, and topic
 				if err := pulsarAdmin.DeleteCluster(destClusterName); err != nil && !admin.IsNotFound(err) {

--- a/pkg/connection/reconcile_namespace.go
+++ b/pkg/connection/reconcile_namespace.go
@@ -121,7 +121,7 @@ func (r *PulsarNamespaceReconciler) ReconcileNamespace(ctx context.Context, puls
 		return nil
 	}
 
-	if namespace.Spec.LifecyclePolicy == resourcev1alpha1.CleanUpAfterDeletion {
+	if namespace.Spec.LifecyclePolicy != resourcev1alpha1.KeepAfterDeletion {
 		// TODO use otelcontroller until kube-instrumentation upgrade controller-runtime version to newer
 		controllerutil.AddFinalizer(namespace, resourcev1alpha1.FinalizerName)
 		if err := r.conn.client.Update(ctx, namespace); err != nil {

--- a/pkg/connection/reconcile_namespace.go
+++ b/pkg/connection/reconcile_namespace.go
@@ -99,7 +99,7 @@ func (r *PulsarNamespaceReconciler) ReconcileNamespace(ctx context.Context, puls
 			}
 		}
 
-		if namespace.Spec.LifecyclePolicy == resourcev1alpha1.CleanUpAfterDeletion {
+		if namespace.Spec.LifecyclePolicy != resourcev1alpha1.KeepAfterDeletion {
 			if err := pulsarAdmin.DeleteNamespace(namespace.Spec.Name); err != nil && !admin.IsNotFound(err) {
 				log.Error(err, "Failed to delete namespace")
 				meta.SetStatusCondition(&namespace.Status.Conditions, *NewErrorCondition(namespace.Generation, err.Error()))

--- a/pkg/connection/reconcile_permission.go
+++ b/pkg/connection/reconcile_permission.go
@@ -105,7 +105,7 @@ func (r *PulsarPermissionReconciler) ReconcilePermission(ctx context.Context, pu
 		return nil
 	}
 
-	if permission.Spec.LifecyclePolicy == resourcev1alpha1.CleanUpAfterDeletion {
+	if permission.Spec.LifecyclePolicy != resourcev1alpha1.KeepAfterDeletion {
 		// TODO use otelcontroller until kube-instrumentation upgrade controller-runtime version to newer
 		controllerutil.AddFinalizer(permission, resourcev1alpha1.FinalizerName)
 		if err := r.conn.client.Update(ctx, permission); err != nil {

--- a/pkg/connection/reconcile_permission.go
+++ b/pkg/connection/reconcile_permission.go
@@ -89,7 +89,7 @@ func (r *PulsarPermissionReconciler) ReconcilePermission(ctx context.Context, pu
 	per := GetPermissioner(permission)
 
 	if !permission.DeletionTimestamp.IsZero() {
-		if permission.Spec.LifecyclePolicy == resourcev1alpha1.CleanUpAfterDeletion {
+		if permission.Spec.LifecyclePolicy != resourcev1alpha1.KeepAfterDeletion {
 			log.Info("Revoking permission", "LifecyclePolicy", permission.Spec.LifecyclePolicy)
 
 			if err := pulsarAdmin.RevokePermissions(per); err != nil && !admin.IsNotFound(err) {

--- a/pkg/connection/reconcile_permission.go
+++ b/pkg/connection/reconcile_permission.go
@@ -89,9 +89,8 @@ func (r *PulsarPermissionReconciler) ReconcilePermission(ctx context.Context, pu
 	per := GetPermissioner(permission)
 
 	if !permission.DeletionTimestamp.IsZero() {
+		log.Info("Revoking permission", "LifecyclePolicy", permission.Spec.LifecyclePolicy)
 		if permission.Spec.LifecyclePolicy != resourcev1alpha1.KeepAfterDeletion {
-			log.Info("Revoking permission", "LifecyclePolicy", permission.Spec.LifecyclePolicy)
-
 			if err := pulsarAdmin.RevokePermissions(per); err != nil && !admin.IsNotFound(err) {
 				log.Error(err, "Failed to revoke permission")
 				return err

--- a/pkg/connection/reconcile_tenant.go
+++ b/pkg/connection/reconcile_tenant.go
@@ -88,7 +88,7 @@ func (r *PulsarTenantReconciler) ReconcileTenant(ctx context.Context, pulsarAdmi
 
 	if !tenant.DeletionTimestamp.IsZero() {
 		log.Info("Deleting tenant", "LifecyclePolicy", tenant.Spec.LifecyclePolicy)
-		if tenant.Spec.LifecyclePolicy == resourcev1alpha1.CleanUpAfterDeletion {
+		if tenant.Spec.LifecyclePolicy != resourcev1alpha1.KeepAfterDeletion {
 			if err := pulsarAdmin.DeleteTenant(tenant.Spec.Name); err != nil && !admin.IsNotFound(err) {
 				log.Error(err, "Failed to delete tenant")
 				return err

--- a/pkg/connection/reconcile_topic.go
+++ b/pkg/connection/reconcile_topic.go
@@ -126,7 +126,7 @@ func (r *PulsarTopicReconciler) ReconcileTopic(ctx context.Context, pulsarAdmin 
 		return nil
 	}
 
-	if topic.Spec.LifecyclePolicy == resourcev1alpha1.CleanUpAfterDeletion {
+	if topic.Spec.LifecyclePolicy != resourcev1alpha1.KeepAfterDeletion {
 		// TODO use otelcontroller until kube-instrumentation upgrade controller-runtime version to newer
 		controllerutil.AddFinalizer(topic, resourcev1alpha1.FinalizerName)
 		if err := r.conn.client.Update(ctx, topic); err != nil {

--- a/pkg/connection/reconcile_topic.go
+++ b/pkg/connection/reconcile_topic.go
@@ -91,7 +91,7 @@ func (r *PulsarTopicReconciler) ReconcileTopic(ctx context.Context, pulsarAdmin 
 	if !topic.DeletionTimestamp.IsZero() {
 		log.Info("Deleting topic", "LifecyclePolicy", topic.Spec.LifecyclePolicy)
 
-		if topic.Spec.LifecyclePolicy == resourcev1alpha1.CleanUpAfterDeletion {
+		if topic.Spec.LifecyclePolicy != resourcev1alpha1.KeepAfterDeletion {
 			// TODO when geoReplicationRef is not nil, it should reset the replication clusters to
 			// default local cluster for the topic
 			if topic.Status.GeoReplicationEnabled {


### PR DESCRIPTION
<!--
### Contribution Checklist

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.

**(The sections below can be removed for hotfixes of typos)**
-->

*(If this PR fixes a github issue, please add `Fixes #<xyz>`.)*

Fixes #158 

*(or if this PR is one task of a github issue, please add `Master Issue: #<xyz>` to link to the master issue.)*

Master Issue: #<xyz>

### Motivation

The resources' by default lifecycle policy is `KeepAfterDeletion`, so if not setting the `lifecyclePolicy` and resources will be kept after deleting the CR. 

This is a little confusing and more natural behavior is to `CleanUpAfterDeletion` as the default behavior and should set it explicitly if users want to keep it. 

### Modifications

Change the default lifecycle policy to `CleanUpAfterDeletion`. 

### Verifying this change

- [x] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

Check the box below.

Need to update docs? 

- [x] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [ ] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)

