### PR TITLE
Sync CR info to pulsar cluster in geo replication object

### DIFF
--- a/pkg/connection/reconcile_geo_replication.go
+++ b/pkg/connection/reconcile_geo_replication.go
@@ -217,7 +217,6 @@ func createParams(ctx context.Context, destConnection *resourcev1alpha1.PulsarCo
 		BrokerClientTrustCertsFilePath: destConnection.Spec.BrokerClientTrustCertsFilePath,
 	}
 
-	hasAuth := true
 	if auth := destConnection.Spec.Authentication; auth != nil {
 		if auth.Token != nil {
 			value, err := GetValue(ctx, client, destConnection.Namespace, auth.Token)
@@ -227,12 +226,11 @@ func createParams(ctx context.Context, destConnection *resourcev1alpha1.PulsarCo
 			if value != nil {
 				clusterParam.AuthPlugin = resourcev1alpha1.AuthPluginToken
 				clusterParam.AuthParameters = "token:" + *value
-				hasAuth = true
 			}
 		}
 		// TODO support oauth2
-		//if auth.OAuth2 != nil && !hasAuth {
-		//}
+		// if auth.OAuth2 != nil && !hasAuth {
+		// }
 	}
 	return clusterParam, nil
 }

--- a/pkg/connection/reconcile_geo_replication.go
+++ b/pkg/connection/reconcile_geo_replication.go
@@ -99,8 +99,6 @@ func (r *PulsarGeoReplicationReconciler) ReconcileGeoReplication(ctx context.Con
 		log.Error(err, "Failed to get destination connection for geo replication")
 		return err
 	}
-	// TODO Currently, if the destination pulsarconnection is updated, the this reconcile won't notice it
-	// Need to fix it in the future work.
 
 	destClusterName := destConnection.Spec.ClusterName
 	if destClusterName == "" {
@@ -149,7 +147,9 @@ func (r *PulsarGeoReplicationReconciler) ReconcileGeoReplication(ctx context.Con
 		return err
 	}
 
-	if resourcev1alpha1.IsPulsarResourceReady(geoReplication) {
+	// if destConnection update, let's update the cluster info
+	if destConnection.Generation == destConnection.Status.ObservedGeneration &&
+		resourcev1alpha1.IsPulsarResourceReady(geoReplication) {
 		// After the previous reconcile succeed, the cluster will be created successfully,
 		// it will update the condition Ready to true, and update the observedGeneration to metadata.generation
 		// If there is no new changes in the object, there is no need to run the left code again.

--- a/pkg/connection/reconcile_geo_replication.go
+++ b/pkg/connection/reconcile_geo_replication.go
@@ -230,9 +230,9 @@ func createParams(ctx context.Context, destConnection *resourcev1alpha1.PulsarCo
 				hasAuth = true
 			}
 		}
-		if auth.OAuth2 != nil && !hasAuth {
-			// TODO support oauth2
-		}
+		// TODO support oauth2
+		//if auth.OAuth2 != nil && !hasAuth {
+		//}
 	}
 	return clusterParam, nil
 }


### PR DESCRIPTION
Fix #164 

### Modifications

Fix geo issue, sync `pulsarConnection` info into pulsar cluster.

<img width="961" alt="image" src="https://github.com/streamnative/pulsar-resources-operator/assets/37220920/160701af-744d-44b4-827f-781463303221">

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)

