### PR TITLE
Add feature gate to always update pulsar & improve log

### DIFF
--- a/.github/workflows/e2e_test.yml
+++ b/.github/workflows/e2e_test.yml
@@ -28,7 +28,7 @@ jobs:
     env:
       GOPRIVATE: github.com/streamnative
       ACCESS_TOKEN: ${{ secrets.ACCESS_TOKEN }}
-      IMAGE: apachepulsar/pulsar:latest
+      IMAGE: apachepulsar/pulsar:latestt
       WATCH_CERT_MANAGER_CRDS: "false"
     steps:
       - name: clean disk

--- a/.github/workflows/e2e_test.yml
+++ b/.github/workflows/e2e_test.yml
@@ -24,8 +24,12 @@ on:
 jobs:
   e2e-test:
     name: E2e tests for Operators
+    strategy:
+      matrix:
+        alwaysUpdatePulsar: [ "true", "false" ]
     runs-on: ubuntu-latest
     env:
+      ALWAYS_UPDATE_PULSAR_RESOURCE: ${{ matrix.alwaysUpdatePulsar }}
       GOPRIVATE: github.com/streamnative
       ACCESS_TOKEN: ${{ secrets.ACCESS_TOKEN }}
       IMAGE: apachepulsar/pulsar:latest

--- a/.github/workflows/e2e_test.yml
+++ b/.github/workflows/e2e_test.yml
@@ -28,7 +28,7 @@ jobs:
     env:
       GOPRIVATE: github.com/streamnative
       ACCESS_TOKEN: ${{ secrets.ACCESS_TOKEN }}
-      IMAGE: apachepulsar/pulsar:latestt
+      IMAGE: apachepulsar/pulsar:latest
       WATCH_CERT_MANAGER_CRDS: "false"
     steps:
       - name: clean disk

--- a/api/v1alpha1/common.go
+++ b/api/v1alpha1/common.go
@@ -17,6 +17,7 @@ package v1alpha1
 import (
 	"reflect"
 
+	"github.com/streamnative/pulsar-resources-operator/pkg/feature"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -73,6 +74,10 @@ type PulsarAuthenticationOAuth2 struct {
 // 2. Status ObservedGeneration is equal with meta.ObservedGeneration
 // 3. StatusCondition Ready is true
 func IsPulsarResourceReady(instance reconciler.Object) bool {
+	if feature.DefaultFeatureGate.Enabled(feature.AlwaysUpdatePulsarResource) {
+		// Always request pulsar service
+		return false
+	}
 	objVal := reflect.ValueOf(instance).Elem()
 	stVal := objVal.FieldByName("Status")
 

--- a/api/v1alpha1/common.go
+++ b/api/v1alpha1/common.go
@@ -17,7 +17,6 @@ package v1alpha1
 import (
 	"reflect"
 
-	"github.com/streamnative/pulsar-resources-operator/pkg/feature"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -74,10 +73,6 @@ type PulsarAuthenticationOAuth2 struct {
 // 2. Status ObservedGeneration is equal with meta.ObservedGeneration
 // 3. StatusCondition Ready is true
 func IsPulsarResourceReady(instance reconciler.Object) bool {
-	if feature.DefaultFeatureGate.Enabled(feature.AlwaysUpdatePulsarResource) {
-		// Always request pulsar service
-		return false
-	}
 	objVal := reflect.ValueOf(instance).Elem()
 	stVal := objVal.FieldByName("Status")
 

--- a/main.go
+++ b/main.go
@@ -19,6 +19,7 @@ import (
 	"flag"
 	"os"
 
+	"github.com/streamnative/pulsar-resources-operator/pkg/feature"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -73,6 +74,11 @@ func main() {
 		encoderConfig.TimeKey = "timestamp"
 		encoderConfig.EncodeTime = zapcore.RFC3339TimeEncoder
 		encoder = zapcore.NewJSONEncoder(encoderConfig)
+	}
+
+	if err := feature.SetFeatureGates(); err != nil {
+		setupLog.Error(err, "failed to set feature gates")
+		os.Exit(1)
 	}
 
 	ctrl.SetLogger(k8szap.New(k8szap.UseFlagOptions(&opts), k8szap.Encoder(encoder)))

--- a/pkg/connection/reconcile_geo_replication.go
+++ b/pkg/connection/reconcile_geo_replication.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 
 	"github.com/go-logr/logr"
+	"github.com/streamnative/pulsar-resources-operator/pkg/feature"
 	"github.com/streamnative/pulsar-resources-operator/pkg/utils"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -177,7 +178,8 @@ func (r *PulsarGeoReplicationReconciler) ReconcileGeoReplication(ctx context.Con
 
 	// if destConnection update, let's update the cluster info
 	if !secretUpdated && destConnection.Generation == destConnection.Status.ObservedGeneration &&
-		resourcev1alpha1.IsPulsarResourceReady(geoReplication) {
+		resourcev1alpha1.IsPulsarResourceReady(geoReplication) &&
+		!feature.DefaultFeatureGate.Enabled(feature.AlwaysUpdatePulsarResource) {
 		// After the previous reconcile succeed, the cluster will be created successfully,
 		// it will update the condition Ready to true, and update the observedGeneration to metadata.generation
 		// If there is no new changes in the object, there is no need to run the left code again.

--- a/pkg/connection/reconcile_geo_replication.go
+++ b/pkg/connection/reconcile_geo_replication.go
@@ -66,8 +66,8 @@ func (r *PulsarGeoReplicationReconciler) Observe(ctx context.Context) error {
 
 	r.conn.geoReplications = geoList.Items
 	// Force the `hasUnreadyResource` to be `true`` to trigger the PulsarConnection reload the auth config
-	if len(geoList.Items) != 0 {
-		r.conn.hasUnreadyResource = true
+	for _, geo := range r.conn.geoReplications {
+		r.conn.addUnreadyResource(&geo)
 	}
 
 	r.log.V(1).Info("Observe Done")

--- a/pkg/connection/reconcile_geo_replication.go
+++ b/pkg/connection/reconcile_geo_replication.go
@@ -66,8 +66,8 @@ func (r *PulsarGeoReplicationReconciler) Observe(ctx context.Context) error {
 
 	r.conn.geoReplications = geoList.Items
 	// Force the `hasUnreadyResource` to be `true`` to trigger the PulsarConnection reload the auth config
-	for _, geo := range r.conn.geoReplications {
-		r.conn.addUnreadyResource(&geo)
+	for i := range geoList.Items {
+		r.conn.addUnreadyResource(&geoList.Items[i])
 	}
 
 	r.log.V(1).Info("Observe Done")

--- a/pkg/connection/reconcile_namespace.go
+++ b/pkg/connection/reconcile_namespace.go
@@ -56,10 +56,10 @@ func (r *PulsarNamespaceReconciler) Observe(ctx context.Context) error {
 	r.log.V(1).Info("Observed namespace items", "Count", len(namespaceList.Items))
 
 	r.conn.namespaces = namespaceList.Items
-	if !r.conn.hasUnreadyResource {
+	if !r.conn.hasUnreadyResource() {
 		for i := range r.conn.namespaces {
 			if !resourcev1alpha1.IsPulsarResourceReady(&r.conn.namespaces[i]) {
-				r.conn.hasUnreadyResource = true
+				r.conn.addUnreadyResource(&r.conn.namespaces[i])
 				break
 			}
 		}

--- a/pkg/connection/reconcile_namespace.go
+++ b/pkg/connection/reconcile_namespace.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 
 	"github.com/go-logr/logr"
+	"github.com/streamnative/pulsar-resources-operator/pkg/feature"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -130,7 +131,8 @@ func (r *PulsarNamespaceReconciler) ReconcileNamespace(ctx context.Context, puls
 		}
 	}
 
-	if resourcev1alpha1.IsPulsarResourceReady(namespace) {
+	if resourcev1alpha1.IsPulsarResourceReady(namespace) &&
+		!feature.DefaultFeatureGate.Enabled(feature.AlwaysUpdatePulsarResource) {
 		log.V(1).Info("Resource is ready")
 		return nil
 	}

--- a/pkg/connection/reconcile_permission.go
+++ b/pkg/connection/reconcile_permission.go
@@ -55,10 +55,10 @@ func (r *PulsarPermissionReconciler) Observe(ctx context.Context) error {
 	r.log.V(1).Info("Observed permissions items", "Count", len(permissionList.Items))
 	r.conn.permissions = permissionList.Items
 
-	if !r.conn.hasUnreadyResource {
+	if !r.conn.hasUnreadyResource() {
 		for i := range r.conn.permissions {
 			if !resourcev1alpha1.IsPulsarResourceReady(&r.conn.permissions[i]) {
-				r.conn.hasUnreadyResource = true
+				r.conn.addUnreadyResource(&r.conn.permissions[i])
 				break
 			}
 		}

--- a/pkg/connection/reconcile_permission.go
+++ b/pkg/connection/reconcile_permission.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 
 	"github.com/go-logr/logr"
+	"github.com/streamnative/pulsar-resources-operator/pkg/feature"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -114,7 +115,8 @@ func (r *PulsarPermissionReconciler) ReconcilePermission(ctx context.Context, pu
 		}
 	}
 
-	if resourcev1alpha1.IsPulsarResourceReady(permission) {
+	if resourcev1alpha1.IsPulsarResourceReady(permission) &&
+		!feature.DefaultFeatureGate.Enabled(feature.AlwaysUpdatePulsarResource) {
 		r.conn.log.V(1).Info("Resource is ready")
 		return nil
 	}

--- a/pkg/connection/reconcile_tenant.go
+++ b/pkg/connection/reconcile_tenant.go
@@ -56,12 +56,9 @@ func (r *PulsarTenantReconciler) Observe(ctx context.Context) error {
 	r.log.V(1).Info("Observed tenants items", "Count", len(tenantList.Items))
 
 	r.conn.tenants = tenantList.Items
-	if !r.conn.hasUnreadyResource {
-		for i := range r.conn.tenants {
-			if !resourcev1alpha1.IsPulsarResourceReady(&r.conn.tenants[i]) {
-				r.conn.hasUnreadyResource = true
-				break
-			}
+	for i := range r.conn.tenants {
+		if !resourcev1alpha1.IsPulsarResourceReady(&r.conn.tenants[i]) {
+			r.conn.addUnreadyResource(&r.conn.tenants[i])
 		}
 	}
 

--- a/pkg/connection/reconcile_tenant.go
+++ b/pkg/connection/reconcile_tenant.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 
 	"github.com/go-logr/logr"
+	"github.com/streamnative/pulsar-resources-operator/pkg/feature"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -109,7 +110,8 @@ func (r *PulsarTenantReconciler) ReconcileTenant(ctx context.Context, pulsarAdmi
 		return err
 	}
 
-	if resourcev1alpha1.IsPulsarResourceReady(tenant) {
+	if resourcev1alpha1.IsPulsarResourceReady(tenant) &&
+		!feature.DefaultFeatureGate.Enabled(feature.AlwaysUpdatePulsarResource) {
 		log.V(1).Info("Resource is ready")
 		return nil
 	}

--- a/pkg/connection/reconcile_topic.go
+++ b/pkg/connection/reconcile_topic.go
@@ -20,6 +20,7 @@ import (
 	"reflect"
 
 	"github.com/go-logr/logr"
+	"github.com/streamnative/pulsar-resources-operator/pkg/feature"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/pointer"
@@ -135,7 +136,8 @@ func (r *PulsarTopicReconciler) ReconcileTopic(ctx context.Context, pulsarAdmin 
 		}
 	}
 
-	if resourcev1alpha1.IsPulsarResourceReady(topic) {
+	if resourcev1alpha1.IsPulsarResourceReady(topic) &&
+		!feature.DefaultFeatureGate.Enabled(feature.AlwaysUpdatePulsarResource) {
 		log.V(1).Info("Resource is ready")
 		return nil
 	}

--- a/pkg/connection/reconcile_topic.go
+++ b/pkg/connection/reconcile_topic.go
@@ -58,10 +58,10 @@ func (r *PulsarTopicReconciler) Observe(ctx context.Context) error {
 	r.log.V(1).Info("Observed topic items", "Count", len(topicsList.Items))
 
 	r.conn.topics = topicsList.Items
-	if !r.conn.hasUnreadyResource {
+	if !r.conn.hasUnreadyResource() {
 		for i := range r.conn.topics {
 			if !resourcev1alpha1.IsPulsarResourceReady(&r.conn.topics[i]) {
-				r.conn.hasUnreadyResource = true
+				r.conn.addUnreadyResource(&r.conn.topics[i])
 				break
 			}
 		}

--- a/pkg/connection/reconciler.go
+++ b/pkg/connection/reconciler.go
@@ -35,16 +35,16 @@ import (
 
 // PulsarConnectionReconciler reconciles a PulsarConnection object
 type PulsarConnectionReconciler struct {
-	connection         *resourcev1alpha1.PulsarConnection
-	log                logr.Logger
-	client             client.Client
-	creator            admin.PulsarAdminCreator
-	tenants            []resourcev1alpha1.PulsarTenant
-	namespaces         []resourcev1alpha1.PulsarNamespace
-	topics             []resourcev1alpha1.PulsarTopic
-	permissions        []resourcev1alpha1.PulsarPermission
-	geoReplications    []resourcev1alpha1.PulsarGeoReplication
-	hasUnreadyResource bool
+	connection       *resourcev1alpha1.PulsarConnection
+	log              logr.Logger
+	client           client.Client
+	creator          admin.PulsarAdminCreator
+	tenants          []resourcev1alpha1.PulsarTenant
+	namespaces       []resourcev1alpha1.PulsarNamespace
+	topics           []resourcev1alpha1.PulsarTopic
+	permissions      []resourcev1alpha1.PulsarPermission
+	geoReplications  []resourcev1alpha1.PulsarGeoReplication
+	unreadyResources []string
 
 	pulsarAdmin admin.PulsarAdmin
 	reconcilers []reconciler.Interface
@@ -56,11 +56,10 @@ var _ reconciler.Interface = &PulsarConnectionReconciler{}
 func MakeReconciler(log logr.Logger, k8sClient client.Client, creator admin.PulsarAdminCreator,
 	connection *resourcev1alpha1.PulsarConnection) reconciler.Interface {
 	r := &PulsarConnectionReconciler{
-		log:                log,
-		connection:         connection,
-		creator:            creator,
-		client:             k8sClient,
-		hasUnreadyResource: false,
+		log:        log,
+		connection: connection,
+		creator:    creator,
+		client:     k8sClient,
 	}
 	r.reconcilers = []reconciler.Interface{
 		makeGeoReplicationReconciler(r),
@@ -86,7 +85,7 @@ func (r *PulsarConnectionReconciler) Observe(ctx context.Context) error {
 func (r *PulsarConnectionReconciler) Reconcile(ctx context.Context) error {
 	var err error
 
-	if !r.hasUnreadyResource {
+	if !r.hasUnreadyResource() {
 		if !r.connection.DeletionTimestamp.IsZero() {
 			if len(r.tenants) == 0 && len(r.namespaces) == 0 && len(r.topics) == 0 && len(r.geoReplications) == 0 {
 				// keep the connection until all resources has been removed
@@ -112,7 +111,7 @@ func (r *PulsarConnectionReconciler) Reconcile(ctx context.Context) error {
 		r.log.Info("Doesn't have unReady resource")
 		return nil
 	}
-	r.log.Info("have unReady resource")
+	r.log.Info("have unReady resource", "unReadyResources", r.unreadyResources)
 
 	if r.connection.Spec.AdminServiceURL == "" && r.connection.Spec.AdminServiceSecureURL != "" {
 		r.connection.Spec.AdminServiceURL = r.connection.Spec.AdminServiceSecureURL
@@ -178,6 +177,15 @@ func (r *PulsarConnectionReconciler) Reconcile(ctx context.Context) error {
 	}
 
 	return nil
+}
+
+func (r *PulsarConnectionReconciler) hasUnreadyResource() bool {
+	return len(r.unreadyResources) > 0
+}
+
+func (r *PulsarConnectionReconciler) addUnreadyResource(obj reconciler.Object) {
+	r.unreadyResources = append(r.unreadyResources, fmt.Sprintf("%s:%s:%s", obj.GetNamespace(),
+		obj.GetNamespace(), obj.GetObjectKind().GroupVersionKind().String()))
 }
 
 // NewErrorCondition create a condition with error

--- a/pkg/connection/reconciler.go
+++ b/pkg/connection/reconciler.go
@@ -185,7 +185,7 @@ func (r *PulsarConnectionReconciler) hasUnreadyResource() bool {
 
 func (r *PulsarConnectionReconciler) addUnreadyResource(obj reconciler.Object) {
 	r.unreadyResources = append(r.unreadyResources, fmt.Sprintf("%s:%s:%s", obj.GetNamespace(),
-		obj.GetNamespace(), obj.GetObjectKind().GroupVersionKind().String()))
+		obj.GetName(), obj.GetObjectKind().GroupVersionKind().String()))
 }
 
 // NewErrorCondition create a condition with error

--- a/pkg/feature/doc.go
+++ b/pkg/feature/doc.go
@@ -12,15 +12,5 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Package feature implements the feature gate
 package feature
-
-import "k8s.io/component-base/featuregate"
-
-const (
-	// AlwaysUpdatePulsarResource is the feature gate for always update pulsar resource
-	AlwaysUpdatePulsarResource featuregate.Feature = "AlwaysUpdatePulsarResource"
-)
-
-var defaultFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
-	AlwaysUpdatePulsarResource: {Default: false, PreRelease: featuregate.Alpha},
-}

--- a/pkg/feature/feature.go
+++ b/pkg/feature/feature.go
@@ -1,0 +1,25 @@
+// Copyright 2022 StreamNative
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package feature
+
+import "k8s.io/component-base/featuregate"
+
+const (
+	AlwaysUpdatePulsarResource featuregate.Feature = "AlwaysUpdatePulsarResource"
+)
+
+var defaultFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
+	AlwaysUpdatePulsarResource: {Default: false, PreRelease: featuregate.Alpha},
+}

--- a/pkg/feature/feature_gate.go
+++ b/pkg/feature/feature_gate.go
@@ -1,0 +1,48 @@
+// Copyright 2022 StreamNative
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package feature
+
+import (
+	"os"
+	"strconv"
+
+	"k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/component-base/featuregate"
+)
+
+var (
+
+	// DefaultMutableFeatureGate is a mutable version of DefaultFeatureGate.
+	DefaultMutableFeatureGate featuregate.MutableFeatureGate = featuregate.NewFeatureGate()
+
+	// DefaultFeatureGate is a shared global FeatureGate.
+	DefaultFeatureGate featuregate.FeatureGate = DefaultMutableFeatureGate
+)
+
+func init() {
+	runtime.Must(DefaultMutableFeatureGate.Add(defaultFeatureGates))
+}
+
+func SetFeatureGates() error {
+	m := map[string]bool{}
+	if v, ok := os.LookupEnv("ALWAYS_UPDATE_PULSAR_RESOURCE"); ok {
+		val, err := strconv.ParseBool(v)
+		if err != nil {
+			return err
+		}
+		m[string(AlwaysUpdatePulsarResource)] = val
+	}
+	return DefaultMutableFeatureGate.SetFromMap(m)
+}

--- a/pkg/feature/feature_gate.go
+++ b/pkg/feature/feature_gate.go
@@ -40,7 +40,7 @@ func SetFeatureGates() error {
 	envFlags := map[string]featuregate.Feature{
 		"ALWAYS_UPDATE_PULSAR_RESOURCE": AlwaysUpdatePulsarResource,
 	}
-	
+
 	m := map[string]bool{}
 	for envVar, feature := range envFlags {
 		if v, ok := os.LookupEnv(envVar); ok {

--- a/pkg/feature/feature_gate.go
+++ b/pkg/feature/feature_gate.go
@@ -35,6 +35,7 @@ func init() {
 	runtime.Must(DefaultMutableFeatureGate.Add(defaultFeatureGates))
 }
 
+// SetFeatureGates sets the provided feature gates.
 func SetFeatureGates() error {
 	m := map[string]bool{}
 	if v, ok := os.LookupEnv("ALWAYS_UPDATE_PULSAR_RESOURCE"); ok {

--- a/pkg/feature/feature_gate.go
+++ b/pkg/feature/feature_gate.go
@@ -37,13 +37,20 @@ func init() {
 
 // SetFeatureGates sets the provided feature gates.
 func SetFeatureGates() error {
-	m := map[string]bool{}
-	if v, ok := os.LookupEnv("ALWAYS_UPDATE_PULSAR_RESOURCE"); ok {
-		val, err := strconv.ParseBool(v)
-		if err != nil {
-			return err
-		}
-		m[string(AlwaysUpdatePulsarResource)] = val
+	envFlags := map[string]featuregate.Feature{
+		"ALWAYS_UPDATE_PULSAR_RESOURCE": AlwaysUpdatePulsarResource,
 	}
+	
+	m := map[string]bool{}
+	for envVar, feature := range envFlags {
+		if v, ok := os.LookupEnv(envVar); ok {
+			val, err := strconv.ParseBool(v)
+			if err != nil {
+				return err
+			}
+			m[string(feature)] = val
+		}
+	}
+
 	return DefaultMutableFeatureGate.SetFromMap(m)
 }

--- a/tests/operator/resources_test.go
+++ b/tests/operator/resources_test.go
@@ -17,7 +17,6 @@ package operator_test
 import (
 	"context"
 	"fmt"
-	"strings"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -232,19 +231,6 @@ var _ = Describe("Resources", func() {
 					format.MaxLength = 0
 					g.Expect(stderr).Should(ContainSubstring("404"))
 				}, "5s", "100ms").Should(Succeed())
-
-				if feature.DefaultFeatureGate.Enabled(feature.AlwaysUpdatePulsarResource) {
-					By("check topic2 is restored in pulsar")
-					Eventually(func(g Gomega) {
-						stdout, stderr, err := utils.ExecInPod(k8sConfig, namespaceName, podName, containerName,
-							"./bin/pulsarctl -s http://localhost:8080 --token=$PROXY_TOKEN"+
-								" topics get "+strings.Split(ptopic2.Spec.Name, "://")[1])
-						format.MaxLength = 0
-						g.Expect(stderr).Should(BeEmpty())
-						g.Expect(stdout).Should(ContainSubstring("partition"))
-						g.Expect(err).Should(Succeed())
-					}, "20s", "100ms").Should(Succeed())
-				}
 			})
 		})
 

--- a/tests/operator/resources_test.go
+++ b/tests/operator/resources_test.go
@@ -162,7 +162,7 @@ var _ = Describe("Resources", func() {
 			})
 		})
 
-		Context("PulsarTopic operation", func() {
+		Context("PulsarTopic operation", Ordered, func() {
 			It("should create the pulsartopic successfully", func() {
 				err := k8sClient.Create(ctx, ptopic)
 				Expect(err == nil || apierrors.IsAlreadyExists(err)).Should(BeTrue())
@@ -203,7 +203,7 @@ var _ = Describe("Resources", func() {
 				}, "20s", "100ms").Should(Succeed())
 			})
 
-			When("enable AlwaysUpdatePulsarResource", func() {
+			When("enable AlwaysUpdatePulsarResource", Ordered, func() {
 				BeforeEach(func() {
 					err := feature.DefaultMutableFeatureGate.SetFromMap(map[string]bool{
 						string(feature.AlwaysUpdatePulsarResource): true,

--- a/tests/operator/resources_test.go
+++ b/tests/operator/resources_test.go
@@ -227,8 +227,7 @@ var _ = Describe("Resources", func() {
 					Expect(err).ShouldNot(HaveOccurred())
 					Expect(stdout).Should(Not(BeEmpty()))
 					format.MaxLength = 0
-					Expect(stderr).Should(BeEmpty())
-					Expect(stdout).Should(ContainSubstring("successfully"))
+					Expect(stderr).Should(ContainSubstring("successfully"))
 
 					By("delete topic1 schema in k8s")
 					topic := &v1alphav1.PulsarTopic{}
@@ -255,7 +254,7 @@ var _ = Describe("Resources", func() {
 						g.Expect(stdout).Should(Not(BeEmpty()))
 						format.MaxLength = 0
 						g.Expect(stdout).Should(ContainSubstring("JSON"))
-					}).Should(Succeed())
+					}, "20s", "100ms").Should(Succeed())
 				})
 			})
 		})

--- a/tests/operator/resources_test.go
+++ b/tests/operator/resources_test.go
@@ -222,9 +222,12 @@ var _ = Describe("Resources", func() {
 					containerName := "pulsar-proxy"
 
 					By("delete topic2 schema with pulsarctl")
-					stdout, _, err := utils.ExecInPod(k8sConfig, namespaceName, podName, containerName,
+					stdout, stderr, err := utils.ExecInPod(k8sConfig, namespaceName, podName, containerName,
 						"./bin/pulsarctl -s http://localhost:8080 --token=$PROXY_TOKEN schemas delete "+ptopic2.Spec.Name)
 					Expect(err).ShouldNot(HaveOccurred())
+					Expect(stdout).Should(Not(BeEmpty()))
+					format.MaxLength = 0
+					Expect(stderr).Should(BeEmpty())
 					Expect(stdout).Should(ContainSubstring("successfully"))
 
 					By("delete topic1 schema in k8s")

--- a/tests/operator/resources_test.go
+++ b/tests/operator/resources_test.go
@@ -249,12 +249,13 @@ var _ = Describe("Resources", func() {
 
 					By("check topic2 is restored in pulsar")
 					Eventually(func(g Gomega) {
-						stdout, _, err := utils.ExecInPod(k8sConfig, namespaceName, podName, containerName,
+						stdout, stderr, err := utils.ExecInPod(k8sConfig, namespaceName, podName, containerName,
 							"./bin/pulsarctl -s http://localhost:8080 --token=$PROXY_TOKEN"+
 								" topics get "+strings.Split(ptopic2.Spec.Name, "://")[1])
 						format.MaxLength = 0
-						g.Expect(err).Should(Succeed())
+						g.Expect(stderr).Should(BeEmpty())
 						g.Expect(stdout).Should(ContainSubstring("partition"))
+						g.Expect(err).Should(Succeed())
 					}, "20s", "100ms").Should(Succeed())
 				})
 			})


### PR DESCRIPTION
Fixes https://github.com/streamnative/eng-support-tickets/issues/867

Fixes https://github.com/streamnative/pulsar-resources-operator/issues/176


### Modifications

1. Add env `ALWAYS_UPDATE_PULSAR_RESOURCE=true` can always sync k8s resource status to pulsar.
2. Improve the log, to list the GVK of unready resources.

### Documentation

Check the box below.

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)

