### PR TITLE
Fixed APK upgrade operation in dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,11 +41,12 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -o manager 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
 FROM alpine:3.20
-WORKDIR /
-COPY --from=builder /workspace/manager .
-USER 65532:65532
 
 # Upgrade all packages to get latest versions with security fixes
 RUN apk upgrade --no-cache
+
+WORKDIR /
+COPY --from=builder /workspace/manager .
+USER 65532:65532
 
 ENTRYPOINT ["/manager"]


### PR DESCRIPTION
### Motivation

The `apk upgrade` step is failing for permission issue because it's done after the user is not root anymore. Changing the order to avoid the issue.


### Modifications

*Describe the modifications you've done.*

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

Check the box below.

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [X] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)

