### PR TITLE
WIP: Implement service account authentication with pulsar

### DIFF
--- a/api/v1alpha1/common.go
+++ b/api/v1alpha1/common.go
@@ -38,10 +38,19 @@ type ValueOrSecretRef struct {
 	SecretRef *SecretKeyRef `json:"secretRef,omitempty"`
 }
 
+// ServiceAccountAuth references a service account to authenticate with pulsar
+type ServiceAccountAuth struct {
+	Name     string `json:"name,omitempty"`
+	Audience string `json:"audience,omitempty"`
+}
+
 // PulsarAuthentication use the token or OAuth2 for pulsar authentication
 type PulsarAuthentication struct {
 	// +optional
 	Token *ValueOrSecretRef `json:"token,omitempty"`
+
+	// +optional
+	ServiceAccount *ServiceAccountAuth `json:"serviceAccount,omitempty"`
 
 	// +optional
 	OAuth2 *PulsarAuthenticationOAuth2 `json:"oauth2,omitempty"`

--- a/pkg/connection/reconciler.go
+++ b/pkg/connection/reconciler.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/go-logr/logr"
 	"github.com/streamnative/pulsar-resources-operator/pkg/utils"
+	authenticationv1 "k8s.io/api/authentication/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -257,6 +258,17 @@ func GetValue(ctx context.Context, k8sClient client.Client, namespace string,
 	return nil, nil
 }
 
+// GetServiceAccountToken obtains a service account token from a service account
+func GetServiceAccountToken(ctx context.Context, k8sClient client.Client, namespace string, serviceAccount string, brokerAudience string) (string, error) {
+	request := &authenticationv1.TokenRequest{}
+	request.Spec.Audiences = []string{brokerAudience}
+	request.Spec.ExpirationSeconds = pointer.Int64(3600)
+	if err := k8sClient.Create(ctx, request); err != nil {
+		return "", err
+	}
+	return request.Status.Token, nil
+}
+
 // MakePulsarAdminConfig create pulsar admin configuration
 func (r *PulsarConnectionReconciler) MakePulsarAdminConfig(ctx context.Context) (*admin.PulsarAdminConfig, error) {
 	return MakePulsarAdminConfig(ctx, r.connection, r.client)
@@ -291,6 +303,12 @@ func MakePulsarAdminConfig(ctx context.Context, connection *resourcev1alpha1.Pul
 			if value != nil {
 				cfg.Token = *value
 				hasAuth = true
+			}
+		}
+		if serviceAccount := authn.ServiceAccount; !hasAuth && serviceAccount != nil {
+			// service account auth
+			cfg.TokenSupplier = func() (string, error) {
+				return GetServiceAccountToken(ctx, k8sClient, connection.Namespace, serviceAccount.Name, serviceAccount.Audience)
 			}
 		}
 		if oauth2 := authn.OAuth2; !hasAuth && oauth2 != nil {

--- a/pkg/utils/pulsar_admin_token_supplier.go
+++ b/pkg/utils/pulsar_admin_token_supplier.go
@@ -1,0 +1,43 @@
+package utils
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/apache/pulsar-client-go/pulsaradmin/pkg/admin/auth"
+)
+
+// tokenSupplierAuthProvider is a custom auth provider for the Pulsar Admin client that can dynamically obtain an
+// auth token, e.g. for Service Accounts
+type tokenSupplierAuthProvider struct {
+	T             http.RoundTripper
+	tokenSupplier func() (string, error)
+}
+
+// NewPulsarAdminAuthProviderWithTokenSupplier creates a new dynamic authentication provider for the pulsar admin client
+func NewPulsarAdminAuthProviderWithTokenSupplier(supplier func() (string, error), t http.RoundTripper) auth.Provider {
+	return &tokenSupplierAuthProvider{
+		T:             t,
+		tokenSupplier: supplier,
+	}
+}
+
+// Transport returns the underlying transport of the provider
+func (t *tokenSupplierAuthProvider) Transport() http.RoundTripper {
+	return t.T
+}
+
+// WithTransport replaces the underlying transport of the provider
+func (t *tokenSupplierAuthProvider) WithTransport(tripper http.RoundTripper) {
+	t.T = tripper
+}
+
+// RoundTrip executes the actual http request enriched with the dynamic token
+func (t *tokenSupplierAuthProvider) RoundTrip(req *http.Request) (*http.Response, error) {
+	token, err := t.tokenSupplier()
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", token))
+	return t.T.RoundTrip(req)
+}


### PR DESCRIPTION
Fixes #125 

### Motivation

Currently, it is not possible to authenticate to a pulsar cluster with OIDC / Kubernetes Service Account tokens.
This PR adds support for it

### Modifications

- Added a reference to a service account as option of the k8s CRD

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

This change ~~added~~ will add tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

Check the box below.

Need to update docs? 

- [x] `doc-required` 
- [ ] `no-need-doc` 
- [ ] `doc` 
