### PR TITLE
Delete resources' cr if pulsar cluster doesn't exist

### DIFF
--- a/pkg/admin/errors.go
+++ b/pkg/admin/errors.go
@@ -16,8 +16,9 @@ package admin
 
 import (
 	"errors"
-	"github.com/apache/pulsar-client-go/pulsaradmin/pkg/rest"
 	"net"
+
+	"github.com/apache/pulsar-client-go/pulsaradmin/pkg/rest"
 )
 
 // Reason indicates the status code

--- a/pkg/admin/errors.go
+++ b/pkg/admin/errors.go
@@ -15,7 +15,9 @@
 package admin
 
 import (
+	"errors"
 	"github.com/apache/pulsar-client-go/pulsaradmin/pkg/rest"
+	"net"
 )
 
 // Reason indicates the status code
@@ -69,4 +71,10 @@ func IsAlreadyExist(err error) bool {
 // IsInternalServerError returns true if the error indicates the resource already exist
 func IsInternalServerError(err error) bool {
 	return ErrorReason(err) == ReasonInternalServerError
+}
+
+// IsNoSuchHostError returns true if operator cannot connect the resource host
+func IsNoSuchHostError(err error) bool {
+	var dnsErr *net.DNSError
+	return errors.As(err, &dnsErr) && dnsErr.Err == "no such host"
 }

--- a/pkg/connection/reconcile_geo_replication.go
+++ b/pkg/connection/reconcile_geo_replication.go
@@ -16,10 +16,7 @@ package connection
 
 import (
 	"context"
-	"errors"
 	"fmt"
-	"net"
-
 	"github.com/go-logr/logr"
 	"github.com/streamnative/pulsar-resources-operator/pkg/feature"
 	"github.com/streamnative/pulsar-resources-operator/pkg/utils"
@@ -156,8 +153,7 @@ func (r *PulsarGeoReplicationReconciler) ReconcileGeoReplication(ctx context.Con
 				// Delete the cluster that created with destination cluster info.
 				// TODO it can only be deleted after the cluster has been removed from the tenant, namespace, and topic
 				if err := pulsarAdmin.DeleteCluster(destClusterName); err != nil && !admin.IsNotFound(err) {
-					var dnsErr *net.DNSError
-					if errors.As(err, &dnsErr) && dnsErr.Err == "no such host" {
+					if admin.IsNoSuchHostError(err) {
 						log.Info("Pulsar cluster has been deleted")
 					} else {
 						log.Error(err, "Failed to delete geo replication cluster")

--- a/pkg/connection/reconcile_geo_replication.go
+++ b/pkg/connection/reconcile_geo_replication.go
@@ -17,6 +17,7 @@ package connection
 import (
 	"context"
 	"fmt"
+
 	"github.com/go-logr/logr"
 	"github.com/streamnative/pulsar-resources-operator/pkg/feature"
 	"github.com/streamnative/pulsar-resources-operator/pkg/utils"

--- a/pkg/connection/reconcile_namespace.go
+++ b/pkg/connection/reconcile_namespace.go
@@ -17,6 +17,7 @@ package connection
 import (
 	"context"
 	"fmt"
+
 	"github.com/go-logr/logr"
 	"github.com/streamnative/pulsar-resources-operator/pkg/feature"
 	"k8s.io/apimachinery/pkg/api/meta"

--- a/pkg/connection/reconcile_tenant.go
+++ b/pkg/connection/reconcile_tenant.go
@@ -17,6 +17,7 @@ package connection
 import (
 	"context"
 	"fmt"
+
 	"github.com/go-logr/logr"
 	"github.com/streamnative/pulsar-resources-operator/pkg/feature"
 	"k8s.io/apimachinery/pkg/api/meta"

--- a/pkg/connection/reconcile_tenant.go
+++ b/pkg/connection/reconcile_tenant.go
@@ -16,7 +16,9 @@ package connection
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"net"
 
 	"github.com/go-logr/logr"
 	"github.com/streamnative/pulsar-resources-operator/pkg/feature"
@@ -88,8 +90,13 @@ func (r *PulsarTenantReconciler) ReconcileTenant(ctx context.Context, pulsarAdmi
 		log.Info("Deleting tenant", "LifecyclePolicy", tenant.Spec.LifecyclePolicy)
 		if tenant.Spec.LifecyclePolicy != resourcev1alpha1.KeepAfterDeletion {
 			if err := pulsarAdmin.DeleteTenant(tenant.Spec.Name); err != nil && !admin.IsNotFound(err) {
-				log.Error(err, "Failed to delete tenant")
-				return err
+				var dnsErr *net.DNSError
+				if errors.As(err, &dnsErr) && dnsErr.Err == "no such host" {
+					log.Info("Pulsar cluster has been deleted")
+				} else {
+					log.Error(err, "Failed to delete tenant")
+					return err
+				}
 			}
 		}
 

--- a/pkg/connection/reconcile_tenant.go
+++ b/pkg/connection/reconcile_tenant.go
@@ -16,10 +16,7 @@ package connection
 
 import (
 	"context"
-	"errors"
 	"fmt"
-	"net"
-
 	"github.com/go-logr/logr"
 	"github.com/streamnative/pulsar-resources-operator/pkg/feature"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -90,8 +87,7 @@ func (r *PulsarTenantReconciler) ReconcileTenant(ctx context.Context, pulsarAdmi
 		log.Info("Deleting tenant", "LifecyclePolicy", tenant.Spec.LifecyclePolicy)
 		if tenant.Spec.LifecyclePolicy != resourcev1alpha1.KeepAfterDeletion {
 			if err := pulsarAdmin.DeleteTenant(tenant.Spec.Name); err != nil && !admin.IsNotFound(err) {
-				var dnsErr *net.DNSError
-				if errors.As(err, &dnsErr) && dnsErr.Err == "no such host" {
+				if admin.IsNoSuchHostError(err) {
 					log.Info("Pulsar cluster has been deleted")
 				} else {
 					log.Error(err, "Failed to delete tenant")

--- a/pkg/connection/reconcile_topic.go
+++ b/pkg/connection/reconcile_topic.go
@@ -99,8 +99,12 @@ func (r *PulsarTopicReconciler) ReconcileTopic(ctx context.Context, pulsarAdmin 
 			if topic.Status.GeoReplicationEnabled {
 				log.Info("GeoReplication is enabled. Reset topic cluster first", "LifecyclePolicy", topic.Spec.LifecyclePolicy, "ClusterName", r.conn.connection.Spec.ClusterName)
 				if err := pulsarAdmin.SetTopicClusters(topic.Spec.Name, topic.Spec.Persistent, []string{r.conn.connection.Spec.ClusterName}); err != nil {
-					log.Error(err, "Failed to reset the cluster for topic")
-					return err
+					if admin.IsNoSuchHostError(err) {
+						log.Info("Pulsar cluster has been deleted")
+					} else {
+						log.Error(err, "Failed to reset the cluster for topic")
+						return err
+					}
 				}
 			}
 


### PR DESCRIPTION
### Motivation

If the pulsar cluster is deleted before the resources' CR deleted, the CRs cannot deleted anymore because they always try to connect to the pulsar cluster.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

Check the box below.

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)

