### PR TITLE
fix: avoid omitting boolean values when serializing

### DIFF
--- a/api/v1alpha1/apikey_types.go
+++ b/api/v1alpha1/apikey_types.go
@@ -50,7 +50,7 @@ type APIKeySpec struct {
 
 	// Revoke indicates whether this API key should be revoked
 	// +optional
-	Revoke bool `json:"revoke,omitempty"`
+	Revoke bool `json:"revoke"`
 
 	// EncryptionKey contains the public key used to encrypt the token
 	// +optional

--- a/api/v1alpha1/common.go
+++ b/api/v1alpha1/common.go
@@ -170,7 +170,7 @@ type ProducerConfig struct {
 	MaxPendingMessagesAcrossPartitions int `json:"maxPendingMessagesAcrossPartitions,omitempty" yaml:"maxPendingMessagesAcrossPartitions"`
 
 	// +optional
-	UseThreadLocalProducers bool `json:"useThreadLocalProducers,omitempty" yaml:"useThreadLocalProducers"`
+	UseThreadLocalProducers bool `json:"useThreadLocalProducers" yaml:"useThreadLocalProducers"`
 
 	// +optional
 	CryptoConfig *CryptoConfig `json:"cryptoConfig,omitempty" yaml:"cryptoConfig"`
@@ -191,7 +191,7 @@ type ConsumerConfig struct {
 	SerdeClassName string `json:"serdeClassName,omitempty" yaml:"serdeClassName"`
 
 	// +optional
-	RegexPattern bool `json:"regexPattern,omitempty" yaml:"regexPattern"`
+	RegexPattern bool `json:"regexPattern" yaml:"regexPattern"`
 
 	// +optional
 	ReceiverQueueSize int `json:"receiverQueueSize,omitempty" yaml:"receiverQueueSize"`
@@ -206,7 +206,7 @@ type ConsumerConfig struct {
 	CryptoConfig *CryptoConfig `json:"cryptoConfig,omitempty" yaml:"cryptoConfig"`
 
 	// +optional
-	PoolMessages bool `json:"poolMessages,omitempty" yaml:"poolMessages"`
+	PoolMessages bool `json:"poolMessages" yaml:"poolMessages"`
 }
 
 // CryptoConfig represents the configuration for the crypto of the pulsar functions and connectors

--- a/api/v1alpha1/computeflinkdeployment_types.go
+++ b/api/v1alpha1/computeflinkdeployment_types.go
@@ -384,7 +384,7 @@ type ComputeFlinkDeploymentList struct {
 
 // VvpRestoreStrategy defines the restore strategy of the deployment
 type VvpRestoreStrategy struct {
-	AllowNonRestoredState bool   `json:"allowNonRestoredState,omitempty"`
+	AllowNonRestoredState bool   `json:"allowNonRestoredState"`
 	Kind                  string `json:"kind,omitempty"`
 }
 

--- a/api/v1alpha1/pulsarconnection_types.go
+++ b/api/v1alpha1/pulsarconnection_types.go
@@ -78,11 +78,11 @@ type PulsarConnectionSpec struct {
 	// TLSEnableHostnameVerification indicates whether to verify the hostname of the broker.
 	// Only used when using secure urls.
 	// +optional
-	TLSEnableHostnameVerification bool `json:"tlsEnableHostnameVerification,omitempty"`
+	TLSEnableHostnameVerification bool `json:"tlsEnableHostnameVerification"`
 
 	// TLSAllowInsecureConnection indicates whether to allow insecure connection to the broker.
 	// +optional
-	TLSAllowInsecureConnection bool `json:"tlsAllowInsecureConnection,omitempty"`
+	TLSAllowInsecureConnection bool `json:"tlsAllowInsecureConnection"`
 
 	// TLSTrustCertsFilePath Path for the TLS certificate used to validate the broker endpoint when using TLS.
 	// +optional

--- a/api/v1alpha1/pulsarnamespace_types.go
+++ b/api/v1alpha1/pulsarnamespace_types.go
@@ -26,7 +26,7 @@ import (
 // TopicAutoCreationConfig defines the configuration for automatic topic creation
 type TopicAutoCreationConfig struct {
 	// Allow specifies whether to allow automatic topic creation
-	Allow bool `json:"allow,omitempty"`
+	Allow bool `json:"allow"`
 
 	// Type specifies the type of automatically created topics
 	// +kubebuilder:validation:Enum=partitioned;non-partitioned
@@ -375,7 +375,7 @@ type PulsarNamespaceStatus struct {
 	// GeoReplicationEnabled indicates whether geo-replication between two Pulsar instances (via PulsarGeoReplication)
 	// is enabled for the namespace
 	// +optional
-	GeoReplicationEnabled bool `json:"geoReplicationEnabled,omitempty"`
+	GeoReplicationEnabled bool `json:"geoReplicationEnabled"`
 }
 
 //+kubebuilder:object:root=true

--- a/api/v1alpha1/pulsartopic_types.go
+++ b/api/v1alpha1/pulsartopic_types.go
@@ -307,7 +307,7 @@ type OffloadPolicies struct {
 // This is a local type definition that mirrors the external library's AutoSubscriptionCreationOverride
 // to ensure proper Kubernetes deep copy generation.
 type AutoSubscriptionCreationOverride struct {
-	AllowAutoSubscriptionCreation bool `json:"allowAutoSubscriptionCreation,omitempty"`
+	AllowAutoSubscriptionCreation bool `json:"allowAutoSubscriptionCreation"`
 }
 
 // SchemaCompatibilityStrategy defines the schema compatibility strategy for a topic.
@@ -340,7 +340,7 @@ type PulsarTopicStatus struct {
 	// GeoReplicationEnabled indicates whether geo-replication is enabled for this topic.
 	// This is set to true when GeoReplicationRefs are configured in the spec and successfully applied.
 	// +optional
-	GeoReplicationEnabled bool `json:"geoReplicationEnabled,omitempty"`
+	GeoReplicationEnabled bool `json:"geoReplicationEnabled"`
 }
 
 //+kubebuilder:object:root=true

--- a/controllers/pulsartopic_boolean_persistence_test.go
+++ b/controllers/pulsartopic_boolean_persistence_test.go
@@ -1,0 +1,84 @@
+// Copyright 2026 StreamNative
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controllers
+
+import (
+	"context"
+	"encoding/json"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	resourcev1alpha1 "github.com/streamnative/pulsar-resources-operator/api/v1alpha1"
+)
+
+var _ = Describe("PulsarTopic Boolean Field Persistence", func() {
+	Context("when PulsarTopic status has GeoReplicationEnabled set to false", func() {
+		It("should preserve false value in JSON serialization", func() {
+			ctx := context.Background()
+			namespace := "default"
+			topicName := "test-geo-replication-false"
+			connectionName := "test-connection"
+
+			connection := &resourcev1alpha1.PulsarConnection{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      connectionName,
+					Namespace: namespace,
+				},
+				Spec: resourcev1alpha1.PulsarConnectionSpec{
+					AdminServiceURL:  "http://localhost:8080",
+					BrokerServiceURL: "pulsar://localhost:6650",
+				},
+			}
+			Expect(k8sClient.Create(ctx, connection)).Should(Succeed())
+
+			topic := &resourcev1alpha1.PulsarTopic{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      topicName,
+					Namespace: namespace,
+				},
+				Spec: resourcev1alpha1.PulsarTopicSpec{
+					Name: "persistent://public/default/" + topicName,
+					ConnectionRef: corev1.LocalObjectReference{
+						Name: connectionName,
+					},
+				},
+				Status: resourcev1alpha1.PulsarTopicStatus{
+					GeoReplicationEnabled: false,
+				},
+			}
+			Expect(k8sClient.Create(ctx, topic)).Should(Succeed())
+
+			// Get the created topic and verify status
+			createdTopic := &resourcev1alpha1.PulsarTopic{}
+			topicKey := types.NamespacedName{Name: topicName, Namespace: namespace}
+			Expect(k8sClient.Get(ctx, topicKey, createdTopic)).Should(Succeed())
+			Expect(createdTopic.Status.GeoReplicationEnabled).Should(Equal(false))
+
+			// Verify the serialization
+			statusJSON, err := json.Marshal(createdTopic.Status)
+			Expect(err).Should(Succeed())
+			var statusMap map[string]interface{}
+			Expect(json.Unmarshal(statusJSON, &statusMap)).Should(Succeed())
+			Expect(statusMap).Should(HaveKey("geoReplicationEnabled"))
+			geoRepValue, exists := statusMap["geoReplicationEnabled"]
+			Expect(exists).Should(BeTrue())
+			Expect(geoRepValue).Should(Equal(false))
+		})
+	})
+})

--- a/pkg/reconciler/stateful_reconciler.go
+++ b/pkg/reconciler/stateful_reconciler.go
@@ -67,7 +67,7 @@ type StateChangeOperations struct {
 
 	// ContextChanged indicates that the context (like resource type or name) has changed
 	// and requires special handling like cleanup of old context
-	ContextChanged bool `json:"contextChanged,omitempty"`
+	ContextChanged bool `json:"contextChanged"`
 
 	// PreviousContext contains the previous context information for cleanup
 	PreviousContext interface{} `json:"previousContext,omitempty"`

--- a/pkg/streamnativecloud/apis/cloud/v1alpha1/apikey_types.go
+++ b/pkg/streamnativecloud/apis/cloud/v1alpha1/apikey_types.go
@@ -53,7 +53,7 @@ type APIKeySpec struct {
 	// Revoke is a boolean that defines if the token of this API key should be revoked.
 	// +kubebuilder:default=false
 	// +optional
-	Revoke bool `json:"revoke,omitempty" protobuf:"bytes,5,opt,name=revoke"`
+	Revoke bool `json:"revoke" protobuf:"bytes,5,opt,name=revoke"`
 
 	// EncryptionKey is a public key to encrypt the API Key token.
 	// Please provide an RSA key with modulus length of at least 2048 bits.

--- a/pkg/streamnativecloud/apis/compute/v1alpha1/flinkdeployment_types.go
+++ b/pkg/streamnativecloud/apis/compute/v1alpha1/flinkdeployment_types.go
@@ -135,7 +135,7 @@ type VvpDeploymentDetails struct {
 
 // VvpRestoreStrategy defines the restore strategy of the deployment
 type VvpRestoreStrategy struct {
-	AllowNonRestoredState bool `json:"allowNonRestoredState,omitempty" protobuf:"varint,1,opt,name=allowNonRestoredState"`
+	AllowNonRestoredState bool `json:"allowNonRestoredState" protobuf:"varint,1,opt,name=allowNonRestoredState"`
 
 	Kind string `json:"kind,omitempty" protobuf:"bytes,2,opt,name=kind"`
 }


### PR DESCRIPTION
Fixes #374

### Motivation

When setting topicAutoCreationConfig.allow: false on a PulsarNamespace resource the operator updates the object with the field removed which causes our gitops tool to reapply the field. Over and over again.

### Modifications

Removed `omitempty` for all boolean fields.

### Verifying this change

- [X] Make sure that the change passes the CI checks.

This change added tests and can be verified as follows:

  - controllers/pulsartopic_boolean_persistence_test.go

### Documentation

- [X] `no-need-doc` 
  
The patch is not a functional change.
