### PR TITLE
ci(release): upgrade openshift-preflight to 1.19.0

### DIFF
--- a/.github/workflows/release-operator.yml
+++ b/.github/workflows/release-operator.yml
@@ -93,7 +93,7 @@ jobs:
           export IMG=$IMAGE_TAG_BASE_QUAY:v$VERSION
           export IMG_LATEST=$IMAGE_TAG_BASE_QUAY:latest
           make docker-build-redhat
-          wget https://github.com/redhat-openshift-ecosystem/openshift-preflight/releases/download/1.16.0/preflight-linux-amd64 -O preflight
+          wget https://github.com/redhat-openshift-ecosystem/openshift-preflight/releases/download/1.19.0/preflight-linux-amd64 -O preflight
           chmod +x preflight
           mv preflight /usr/local/bin
           preflight -v


### PR DESCRIPTION
### Motivation

The Red Hat certification release step started failing because Pyxis no longer accepts results submitted by `openshift-preflight` 1.16.0:

```
could not submit to pyxis: could not create test results: status code: 400:
body: {"detail": "Validation error: 'github.com/redhat-openshift-ecosystem/openshift-preflight' version '1.16.0' is not supported. Supported versions are: ['1.19.0']", "status": 400}
```

Pyxis now only accepts version `1.19.0`.

### Modifications

- Bump the `openshift-preflight` download URL in `.github/workflows/release-operator.yml` from `1.16.0` to `1.19.0`.

The version was hardcoded only in the release workflow; the `Makefile` just invokes the `preflight` binary installed by the workflow, so no other changes are needed.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

This change is a trivial rework / code cleanup without any test coverage. On the next release, `preflight -v` should report `1.19.0` and `make report-preflight-check-result` should no longer return a 400 from Pyxis.

### Documentation

- [x] `no-need-doc`

  CI-only change to the release workflow; no user-facing behavior or docs affected.