### PR TITLE
fix(rbac): Add aggregation labels to the clusterrole

### DIFF
--- a/charts/pulsar-resources-operator/templates/role.yaml
+++ b/charts/pulsar-resources-operator/templates/role.yaml
@@ -19,6 +19,9 @@ kind: ClusterRole
 metadata:
   creationTimestamp: null
   name: {{ include "pulsar-resources-operator.clusterRoleManagerName" . }}
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
 rules:
 - apiGroups:
   - ""

--- a/charts/pulsar-resources-operator/tests/rbac_test.yaml
+++ b/charts/pulsar-resources-operator/tests/rbac_test.yaml
@@ -1,0 +1,42 @@
+# Copyright 2024 StreamNative
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+suite: test rbac
+templates:
+  - role.yaml
+  - role_binding.yaml
+tests:
+  - it: should pass all default settings
+    asserts:
+      - isAPIVersion:
+          of: rbac.authorization.k8s.io/v1
+      - isKind:
+          of: ClusterRole
+        template: role.yaml
+      - isKind:
+          of: ClusterRoleBinding
+        template: role_binding.yaml
+      - matchRegex:
+          path: metadata.name
+          pattern: -pulsar-resources-operator
+
+  - it: should reference the agregate to edit and admin roles
+    asserts:
+      - template: role.yaml
+        isSubset:
+            path: metadata.labels
+            content:
+              rbac.authorization.k8s.io/aggregate-to-edit: "true"
+              rbac.authorization.k8s.io/aggregate-to-admin: "true"


### PR DESCRIPTION
Fixes #415

### Motivation

The ClusterRole shipped by this chart does not carry any RBAC aggregation labels, so users or service accounts bound to the standard Kubernetes admin / edit ClusterRoles cannot manage the operator's CRDs (PulsarTenant, PulsarNamespace, PulsarTopic, ...) out of the box. Every consumer has to either add extra ClusterRoleBindings or patch the chart via post-rendering to inject the labels.

### Modifications

Added the standard RBAC aggregation labels to the manager ClusterRole template:

```yaml
metadata:
  labels:
    rbac.authorization.k8s.io/aggregate-to-admin: "true"
    rbac.authorization.k8s.io/aggregate-to-edit: "true"
```

This is the minimal change discussed in the linked issue. The optional companion read-only ClusterRole (aggregate-to-view) and the values.yaml toggles are intentionally left out of this PR, happy to follow up with a second PR based on maintainer feedback.

### Verifying this change

- [X] Make sure that the change passes the CI checks.

This change added tests and can be verified as follows:

*helm unittest*
- added minimal default tests on role and role_binding
- added a test on labels presence

### Documentation

- [x] no-need-doc

This change only affects the rendered RBAC manifests. It does not introduce new APIs, configuration values, or user-facing behaviour that would require documentation updates.

