### PR TITLE
fix(namespace): converge bookie affinity group instead of blind-writing

### DIFF
--- a/api/v1alpha1/pulsarnamespace_types.go
+++ b/api/v1alpha1/pulsarnamespace_types.go
@@ -253,7 +253,12 @@ type PulsarNamespaceSpec struct {
 	// +optional
 	Deduplication *bool `json:"deduplication,omitempty"`
 
-	// BookieAffinityGroup is the name of the namespace isolation policy to apply to the namespace.
+	// BookieAffinityGroup pins the namespace's ledgers to the bookies that belong to the
+	// named BookKeeper rack/affinity groups. This is the storage half of a namespace
+	// carve-out; pair it with a PulsarNSIsolationPolicy to also pin the namespace to a
+	// dedicated set of brokers.
+	// Omitting this field removes any affinity group previously set for the namespace.
+	// +optional
 	BookieAffinityGroup *BookieAffinityGroupData `json:"bookieAffinityGroup,omitempty"`
 
 	// TopicAutoCreationConfig controls whether automatic topic creation is allowed in this namespace
@@ -344,9 +349,17 @@ type PulsarNamespaceSpec struct {
 	SchemaAutoUpdateCompatibilityStrategy *adminutils.SchemaAutoUpdateCompatibilityStrategy `json:"schemaAutoUpdateCompatibilityStrategy,omitempty"`
 }
 
+// BookieAffinityGroupData selects the BookKeeper rack/affinity groups that a namespace's
+// ledgers are placed on. The group names must match the rack metadata already registered
+// for the bookies; the operator does not create group membership.
 type BookieAffinityGroupData struct {
+	// BookkeeperAffinityGroupPrimary is the group bookies are selected from first.
+	// +kubebuilder:validation:MinLength=1
 	BookkeeperAffinityGroupPrimary string `json:"bookkeeperAffinityGroupPrimary"`
 
+	// BookkeeperAffinityGroupSecondary is the group bookies are selected from when the
+	// primary group cannot satisfy the ensemble.
+	// +kubebuilder:validation:MinLength=1
 	// +optional
 	BookkeeperAffinityGroupSecondary string `json:"bookkeeperAffinityGroupSecondary,omitempty"`
 }

--- a/charts/pulsar-resources-operator/crds/resource.streamnative.io_pulsarnamespaces.yaml
+++ b/charts/pulsar-resources-operator/crds/resource.streamnative.io_pulsarnamespaces.yaml
@@ -113,12 +113,23 @@ spec:
                 - message_age
                 type: string
               bookieAffinityGroup:
-                description: BookieAffinityGroup is the name of the namespace isolation
-                  policy to apply to the namespace.
+                description: |-
+                  BookieAffinityGroup pins the namespace's ledgers to the bookies that belong to the
+                  named BookKeeper rack/affinity groups. This is the storage half of a namespace
+                  carve-out; pair it with a PulsarNSIsolationPolicy to also pin the namespace to a
+                  dedicated set of brokers.
+                  Omitting this field removes any affinity group previously set for the namespace.
                 properties:
                   bookkeeperAffinityGroupPrimary:
+                    description: BookkeeperAffinityGroupPrimary is the group bookies
+                      are selected from first.
+                    minLength: 1
                     type: string
                   bookkeeperAffinityGroupSecondary:
+                    description: |-
+                      BookkeeperAffinityGroupSecondary is the group bookies are selected from when the
+                      primary group cannot satisfy the ensemble.
+                    minLength: 1
                     type: string
                 required:
                 - bookkeeperAffinityGroupPrimary

--- a/config/crd/bases/resource.streamnative.io_pulsarnamespaces.yaml
+++ b/config/crd/bases/resource.streamnative.io_pulsarnamespaces.yaml
@@ -113,12 +113,23 @@ spec:
                 - message_age
                 type: string
               bookieAffinityGroup:
-                description: BookieAffinityGroup is the name of the namespace isolation
-                  policy to apply to the namespace.
+                description: |-
+                  BookieAffinityGroup pins the namespace's ledgers to the bookies that belong to the
+                  named BookKeeper rack/affinity groups. This is the storage half of a namespace
+                  carve-out; pair it with a PulsarNSIsolationPolicy to also pin the namespace to a
+                  dedicated set of brokers.
+                  Omitting this field removes any affinity group previously set for the namespace.
                 properties:
                   bookkeeperAffinityGroupPrimary:
+                    description: BookkeeperAffinityGroupPrimary is the group bookies
+                      are selected from first.
+                    minLength: 1
                     type: string
                   bookkeeperAffinityGroupSecondary:
+                    description: |-
+                      BookkeeperAffinityGroupSecondary is the group bookies are selected from when the
+                      primary group cannot satisfy the ensemble.
+                    minLength: 1
                     type: string
                 required:
                 - bookkeeperAffinityGroupPrimary

--- a/docs/pulsar_namespace.md
+++ b/docs/pulsar_namespace.md
@@ -28,7 +28,7 @@ The `PulsarNamespace` resource defines a namespace in a Pulsar cluster. It allow
 | `geoReplicationRefs`          | List of references to PulsarGeoReplication resources, used to configure geo-replication for this namespace. Use only when using PulsarGeoReplication for setting up geo-replication between two Pulsar instances. | No       |
 | `replicationClusters`         | List of clusters to which the namespace is replicated. Use only if replicating clusters within the same Pulsar instance.                                                                                          | No       |
 | `deduplication`               | Whether to enable message deduplication for the namespace.                                                                                                                                                        | No       |
-| `bookieAffinityGroup`         | Set the bookie-affinity group for the namespace, which has two sub fields: `bookkeeperAffinityGroupPrimary(String)` is required, and `bookkeeperAffinityGroupSecondary(String)` is optional.                      | No       |
+| `bookieAffinityGroup`         | Pins the namespace's ledgers to the bookies belonging to the named BookKeeper rack/affinity groups. Two sub fields: `bookkeeperAffinityGroupPrimary(String)` is required, `bookkeeperAffinityGroupSecondary(String)` is optional. See [Broker and Bookie Isolation](#broker-and-bookie-isolation). | No       |
 | `topicAutoCreationConfig`     | Configures automatic topic creation behavior within this namespace. Contains settings for whether auto-creation is allowed, the type of topics created, and default number of partitions.                          | No       |
 | `schemaCompatibilityStrategy` | Schema compatibility strategy for this namespace. Controls how schema evolution is handled for topics within this namespace. Options: `UNDEFINED`, `ALWAYS_INCOMPATIBLE`, `ALWAYS_COMPATIBLE`, `BACKWARD`, `FORWARD`, `FULL`, `BACKWARD_TRANSITIVE`, `FORWARD_TRANSITIVE`, `FULL_TRANSITIVE`.                                                          | No       |
 | `schemaValidationEnforced`    | Controls whether schema validation is enforced for this namespace. When enabled, producers must provide a schema when publishing messages. If not specified, the cluster's default schema validation enforcement setting will be used.                                                                                                  | No       |
@@ -308,6 +308,93 @@ persistencePolicies:
   bookkeeperAckQuorum: 1
   managedLedgerMaxMarkDeleteRate: "10.0"
 ```
+
+## Broker and Bookie Isolation
+
+A namespace carve-out on a shared cluster has two halves, and they are configured through
+two different resources:
+
+| Half | Pins | Resource |
+| --- | --- | --- |
+| Brokers | Which brokers may own the namespace's bundles | [`PulsarNSIsolationPolicy`](pulsar_ns_isolation_policy.md) |
+| Bookies | Which bookies the namespace's ledgers are written to | `PulsarNamespace.spec.bookieAffinityGroup` |
+
+The two are independent — configure either on its own, or both together for a full
+"virtual cluster" per tenant or subsystem.
+
+### Bookie Affinity Groups
+
+`bookieAffinityGroup` is the declarative equivalent of
+`pulsar-admin namespaces set-bookie-affinity-group`:
+
+```yaml
+bookieAffinityGroup:
+  bookkeeperAffinityGroupPrimary: subsystem-a      # required
+  bookkeeperAffinityGroupSecondary: subsystem-a-dr # optional
+```
+
+Bookies are selected from the primary group first, falling back to the secondary group when
+the primary cannot satisfy the ensemble. Removing the `bookieAffinityGroup` field from the
+CR removes the affinity policy from the namespace, returning it to cluster-wide bookie
+placement.
+
+**Prerequisite:** the group names must match rack metadata that the bookies already carry
+(`bookkeeper-rack-aware` placement, set through bookie configuration or BookKeeper metadata).
+The operator selects among existing groups; it does not create group membership. Setting an
+affinity group whose members cannot satisfy the namespace's ensemble size will cause writes
+to fail, so verify group membership before applying.
+
+**Permissions:** Pulsar requires superuser access to read, set, or clear a namespace's bookie
+affinity group. A `PulsarConnection` whose credentials are only tenant-admin can manage
+namespaces normally, but cannot use this field.
+
+### Complete Carve-Out Example
+
+Pinning `finance/transactions` to dedicated brokers *and* dedicated bookies:
+
+```yaml
+apiVersion: resource.streamnative.io/v1alpha1
+kind: PulsarNSIsolationPolicy
+metadata:
+  name: finance-isolation
+  namespace: default
+spec:
+  name: finance-isolation
+  cluster: my-pulsar-cluster
+  connectionRef:
+    name: my-connection
+  namespaces:
+    - finance/.*
+  primary:
+    - broker-finance-.*\.example\.com
+  secondary:
+    - broker-shared-.*\.example\.com
+  autoFailoverPolicyType: min_available
+  autoFailoverPolicyParams:
+    min_limit: "1"
+    usage_threshold: "80"
+---
+apiVersion: resource.streamnative.io/v1alpha1
+kind: PulsarNamespace
+metadata:
+  name: finance-transactions
+  namespace: default
+spec:
+  name: finance/transactions
+  connectionRef:
+    name: my-connection
+  bookieAffinityGroup:
+    bookkeeperAffinityGroupPrimary: finance
+    bookkeeperAffinityGroupSecondary: shared
+  persistencePolicies:
+    bookkeeperEnsemble: 3
+    bookkeeperWriteQuorum: 3
+    bookkeeperAckQuorum: 2
+```
+
+Note that `persistencePolicies` and `bookieAffinityGroup` work together: the affinity group
+decides *which* bookies are eligible, and the ensemble/quorum settings decide *how many* of
+them each ledger uses. The eligible groups must contain at least `bookkeeperEnsemble` bookies.
 
 ## Topic Management Policies
 

--- a/docs/pulsar_ns_isolation_policy.md
+++ b/docs/pulsar_ns_isolation_policy.md
@@ -4,6 +4,8 @@
 
 The `PulsarNSIsolationPolicy` resource defines a ns-isolation-policy in a Pulsar cluster. It allows you to configure namespace isolation policies to limit the set of brokers that can be used for assignment.
 
+This resource covers the broker half of a namespace carve-out. To also pin a namespace's storage to a dedicated set of bookies, pair it with `bookieAffinityGroup` on the [`PulsarNamespace`](pulsar_namespace.md#broker-and-bookie-isolation) resource.
+
 ## Specifications
 
 | Field                      | Description                                                                                          | Required |

--- a/pkg/admin/bookie_affinity_group_test.go
+++ b/pkg/admin/bookie_affinity_group_test.go
@@ -215,3 +215,100 @@ func TestApplyBookieAffinityGroupPropagatesReadFailure(t *testing.T) {
 		t.Fatalf("error reason = %v, want %v", reason, ReasonForbidden)
 	}
 }
+
+const autoTopicCreationPath = "/admin/v2/namespaces/public/default/autoTopicCreation"
+
+// affinityDenialServer answers the bookie affinity endpoint with status and records every
+// path the reconcile touches, so a test can assert what still ran after the denial.
+func affinityDenialServer(t *testing.T, status int, paths *[]string) *httptest.Server {
+	t.Helper()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		*paths = append(*paths, r.URL.EscapedPath())
+		if r.URL.EscapedPath() == bookieAffinityPath {
+			http.Error(w, "Don't have admin permission", status)
+			return
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	t.Cleanup(server.Close)
+	return server
+}
+
+func contains(paths []string, want string) bool {
+	for _, p := range paths {
+		if p == want {
+			return true
+		}
+	}
+	return false
+}
+
+// Reading the bookie affinity group is superuser-only in Pulsar, so a tenant-admin
+// connection is denied on it even for a namespace that never asked for a group. That
+// denial must not abort the reconcile: every policy after it would be skipped and the
+// namespace would never reach Ready.
+func TestApplyNamespacePoliciesToleratesDeniedAffinityReadWhenUnset(t *testing.T) {
+	for _, status := range []int{http.StatusUnauthorized, http.StatusForbidden} {
+		t.Run(http.StatusText(status), func(t *testing.T) {
+			var paths []string
+			server := affinityDenialServer(t, status, &paths)
+
+			client, err := pulsaradmin.New(&config.Config{WebServiceURL: server.URL})
+			if err != nil {
+				t.Fatalf("create Pulsar admin client: %v", err)
+			}
+
+			adminClient := &PulsarAdminClient{adminClient: client}
+			err = adminClient.applyNamespacePolicies("public/default", &NamespaceParams{
+				BookieAffinityGroup: nil,
+				TopicAutoCreationConfig: &resourcev1alpha1.TopicAutoCreationConfig{
+					Allow: true,
+					Type:  "non-partitioned",
+				},
+			})
+			if err != nil {
+				t.Fatalf("apply namespace policies: %v", err)
+			}
+
+			if !contains(paths, bookieAffinityPath) {
+				t.Fatalf("bookie affinity was never read, paths = %v", paths)
+			}
+			// The policy that follows the affinity block must still have been applied.
+			if !contains(paths, autoTopicCreationPath) {
+				t.Fatalf("a later policy was skipped after the denied read, paths = %v", paths)
+			}
+		})
+	}
+}
+
+// A group the user explicitly asked for is the opposite case: the operator has been told
+// to write it, so a permission failure has to surface rather than be silently skipped.
+func TestApplyNamespacePoliciesFailsOnDeniedAffinityReadWhenRequested(t *testing.T) {
+	for _, status := range []int{http.StatusUnauthorized, http.StatusForbidden} {
+		t.Run(http.StatusText(status), func(t *testing.T) {
+			var paths []string
+			server := affinityDenialServer(t, status, &paths)
+
+			client, err := pulsaradmin.New(&config.Config{WebServiceURL: server.URL})
+			if err != nil {
+				t.Fatalf("create Pulsar admin client: %v", err)
+			}
+
+			adminClient := &PulsarAdminClient{adminClient: client}
+			err = adminClient.applyNamespacePolicies("public/default", &NamespaceParams{
+				BookieAffinityGroup: &resourcev1alpha1.BookieAffinityGroupData{
+					BookkeeperAffinityGroupPrimary: "group-a",
+				},
+			})
+			if err == nil {
+				t.Fatal("apply namespace policies succeeded, want error")
+			}
+			if !IsPermissionDenied(err) {
+				t.Fatalf("error reason = %v, want a permission denial", ErrorReason(err))
+			}
+			if contains(paths, autoTopicCreationPath) {
+				t.Fatalf("reconcile continued past a required write it could not make, paths = %v", paths)
+			}
+		})
+	}
+}

--- a/pkg/admin/bookie_affinity_group_test.go
+++ b/pkg/admin/bookie_affinity_group_test.go
@@ -1,0 +1,217 @@
+// Copyright 2026 StreamNative
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package admin
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	pulsaradmin "github.com/apache/pulsar-client-go/pulsaradmin/pkg/admin"
+	"github.com/apache/pulsar-client-go/pulsaradmin/pkg/admin/config"
+
+	resourcev1alpha1 "github.com/streamnative/pulsar-resources-operator/api/v1alpha1"
+)
+
+const bookieAffinityPath = "/admin/v2/namespaces/public/default/persistence/bookieAffinity"
+
+// currentAffinity models what Pulsar reports for a namespace's bookie affinity group.
+type currentAffinity struct {
+	// status is the response code for GET, 404 meaning the namespace has no local policies.
+	status int
+	// body is the JSON payload returned when status is 200.
+	body string
+}
+
+var (
+	affinityAbsent = currentAffinity{status: http.StatusNotFound}
+	// Pulsar answers 200 with an empty group when local policies exist but the affinity
+	// group was cleared.
+	affinityCleared = currentAffinity{status: http.StatusOK, body: `{}`}
+	affinityGroupA  = currentAffinity{
+		status: http.StatusOK,
+		body:   `{"bookkeeperAffinityGroupPrimary":"group-a","bookkeeperAffinityGroupSecondary":"group-b"}`,
+	}
+)
+
+func TestApplyBookieAffinityGroup(t *testing.T) {
+	tests := []struct {
+		name         string
+		desired      *resourcev1alpha1.BookieAffinityGroupData
+		current      currentAffinity
+		wantMethods  []string
+		wantPostBody map[string]string
+	}{
+		{
+			// Setting and clearing the affinity group both require superuser access in
+			// Pulsar, so a namespace that never uses the feature must not write at all.
+			name:        "unset stays unset without writing",
+			desired:     nil,
+			current:     affinityAbsent,
+			wantMethods: []string{http.MethodGet},
+		},
+		{
+			name:        "cleared group is not deleted again",
+			desired:     nil,
+			current:     affinityCleared,
+			wantMethods: []string{http.MethodGet},
+		},
+		{
+			name:        "removing the setting deletes the group",
+			desired:     nil,
+			current:     affinityGroupA,
+			wantMethods: []string{http.MethodGet, http.MethodDelete},
+		},
+		{
+			name: "group is set when none exists",
+			desired: &resourcev1alpha1.BookieAffinityGroupData{
+				BookkeeperAffinityGroupPrimary:   "group-a",
+				BookkeeperAffinityGroupSecondary: "group-b",
+			},
+			current:     affinityAbsent,
+			wantMethods: []string{http.MethodGet, http.MethodPost},
+			wantPostBody: map[string]string{
+				"bookkeeperAffinityGroupPrimary":   "group-a",
+				"bookkeeperAffinityGroupSecondary": "group-b",
+			},
+		},
+		{
+			name: "matching group is left alone",
+			desired: &resourcev1alpha1.BookieAffinityGroupData{
+				BookkeeperAffinityGroupPrimary:   "group-a",
+				BookkeeperAffinityGroupSecondary: "group-b",
+			},
+			current:     affinityGroupA,
+			wantMethods: []string{http.MethodGet},
+		},
+		{
+			name: "changed group is rewritten",
+			desired: &resourcev1alpha1.BookieAffinityGroupData{
+				BookkeeperAffinityGroupPrimary: "group-c",
+			},
+			current:     affinityGroupA,
+			wantMethods: []string{http.MethodGet, http.MethodPost},
+			wantPostBody: map[string]string{
+				"bookkeeperAffinityGroupPrimary":   "group-c",
+				"bookkeeperAffinityGroupSecondary": "",
+			},
+		},
+		{
+			// Dropping the secondary group is a real change even though the primary matches.
+			name: "dropping the secondary group is rewritten",
+			desired: &resourcev1alpha1.BookieAffinityGroupData{
+				BookkeeperAffinityGroupPrimary: "group-a",
+			},
+			current:     affinityGroupA,
+			wantMethods: []string{http.MethodGet, http.MethodPost},
+			wantPostBody: map[string]string{
+				"bookkeeperAffinityGroupPrimary":   "group-a",
+				"bookkeeperAffinityGroupSecondary": "",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var methods []string
+			var postBody map[string]string
+
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.EscapedPath() != bookieAffinityPath {
+					t.Errorf("unexpected request to %s", r.URL.EscapedPath())
+					w.WriteHeader(http.StatusNotImplemented)
+					return
+				}
+				methods = append(methods, r.Method)
+
+				switch r.Method {
+				case http.MethodGet:
+					if tt.current.status != http.StatusOK {
+						http.Error(w, "Namespace local-policies does not exist", tt.current.status)
+						return
+					}
+					w.Header().Set("Content-Type", "application/json")
+					_, _ = io.WriteString(w, tt.current.body)
+				case http.MethodPost:
+					if err := json.NewDecoder(r.Body).Decode(&postBody); err != nil {
+						t.Errorf("decode bookie affinity payload: %v", err)
+					}
+					w.WriteHeader(http.StatusNoContent)
+				default:
+					w.WriteHeader(http.StatusNoContent)
+				}
+			}))
+			t.Cleanup(server.Close)
+
+			client, err := pulsaradmin.New(&config.Config{WebServiceURL: server.URL})
+			if err != nil {
+				t.Fatalf("create Pulsar admin client: %v", err)
+			}
+
+			adminClient := &PulsarAdminClient{adminClient: client}
+			if err := adminClient.applyBookieAffinityGroup("public/default", tt.desired); err != nil {
+				t.Fatalf("apply bookie affinity group: %v", err)
+			}
+
+			if len(methods) != len(tt.wantMethods) {
+				t.Fatalf("requests = %v, want %v", methods, tt.wantMethods)
+			}
+			for i := range tt.wantMethods {
+				if methods[i] != tt.wantMethods[i] {
+					t.Fatalf("request[%d] = %s, want %s", i, methods[i], tt.wantMethods[i])
+				}
+			}
+
+			if tt.wantPostBody == nil {
+				return
+			}
+			for key, want := range tt.wantPostBody {
+				if got := postBody[key]; got != want {
+					t.Fatalf("post body %q = %q, want %q", key, got, want)
+				}
+			}
+		})
+	}
+}
+
+// A GET failure that is not a 404 must surface rather than be mistaken for "no group set",
+// which would otherwise let the operator silently skip a required write.
+func TestApplyBookieAffinityGroupPropagatesReadFailure(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("unexpected %s request after a failed read", r.Method)
+		}
+		http.Error(w, "Don't have admin permission", http.StatusForbidden)
+	}))
+	t.Cleanup(server.Close)
+
+	client, err := pulsaradmin.New(&config.Config{WebServiceURL: server.URL})
+	if err != nil {
+		t.Fatalf("create Pulsar admin client: %v", err)
+	}
+
+	adminClient := &PulsarAdminClient{adminClient: client}
+	err = adminClient.applyBookieAffinityGroup("public/default", &resourcev1alpha1.BookieAffinityGroupData{
+		BookkeeperAffinityGroupPrimary: "group-a",
+	})
+	if err == nil {
+		t.Fatal("apply bookie affinity group succeeded, want error")
+	}
+	if reason := ErrorReason(err); reason != ReasonForbidden {
+		t.Fatalf("error reason = %v, want %v", reason, ReasonForbidden)
+	}
+}

--- a/pkg/admin/errors.go
+++ b/pkg/admin/errors.go
@@ -75,6 +75,17 @@ func IsNotFound(err error) bool {
 	return ErrorReason(err) == ReasonNotFound
 }
 
+// IsPermissionDenied returns true if the error indicates the connection lacks the
+// permission the operation requires, either because it did not authenticate (401) or
+// because the authenticated role is not allowed to perform it (403).
+//
+// Some Pulsar endpoints are superuser-only regardless of tenant role, so a tenant-admin
+// connection can hit this on a namespace it otherwise fully controls.
+func IsPermissionDenied(err error) bool {
+	reason := ErrorReason(err)
+	return reason == ReasonUnauthorized || reason == ReasonForbidden
+}
+
 // IsAlreadyExist returns true if the error indicates the resource already exist
 func IsAlreadyExist(err error) bool {
 	if err == nil {

--- a/pkg/admin/errors_test.go
+++ b/pkg/admin/errors_test.go
@@ -88,3 +88,62 @@ func TestIsAlreadyExist(t *testing.T) {
 		})
 	}
 }
+
+func TestIsPermissionDenied(t *testing.T) {
+	tests := []struct {
+		name     string
+		err      error
+		expected bool
+	}{
+		{
+			name:     "rest.Error with 401",
+			err:      rest.Error{Code: 401, Reason: "Need to authenticate to perform the request"},
+			expected: true,
+		},
+		{
+			name:     "rest.Error with 403",
+			err:      rest.Error{Code: 403, Reason: "Don't have admin permission"},
+			expected: true,
+		},
+		{
+			name:     "rest.Error pointer with 403",
+			err:      &rest.Error{Code: 403, Reason: "Don't have admin permission"},
+			expected: true,
+		},
+		{
+			name:     "wrapped rest.Error with 403",
+			err:      fmt.Errorf("wrapped: %w", rest.Error{Code: 403, Reason: "Don't have admin permission"}),
+			expected: true,
+		},
+		{
+			// 404 is how Pulsar reports a namespace with no local policies, which is a
+			// legitimate "nothing set" answer rather than a denial.
+			name:     "rest.Error with 404",
+			err:      rest.Error{Code: 404, Reason: "Namespace local-policies does not exist"},
+			expected: false,
+		},
+		{
+			name:     "rest.Error with 500",
+			err:      rest.Error{Code: 500, Reason: "Internal server error"},
+			expected: false,
+		},
+		{
+			name:     "non-REST error",
+			err:      errors.New("connection refused"),
+			expected: false,
+		},
+		{
+			name:     "nil error",
+			err:      nil,
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsPermissionDenied(tt.err); got != tt.expected {
+				t.Errorf("IsPermissionDenied(%v) = %v, want %v", tt.err, got, tt.expected)
+			}
+		})
+	}
+}

--- a/pkg/admin/impl.go
+++ b/pkg/admin/impl.go
@@ -26,10 +26,15 @@ import (
 	"github.com/apache/pulsar-client-go/pulsaradmin/pkg/utils"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/utils/ptr"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
 	"github.com/streamnative/pulsar-resources-operator/api/v1alpha1"
 	rutils "github.com/streamnative/pulsar-resources-operator/pkg/utils"
 )
+
+// bookieAffinityLog reports the one case where this package cannot converge a policy and
+// deliberately does not fail the reconcile, which would otherwise be invisible.
+var bookieAffinityLog = logf.Log.WithName("bookie-affinity-group")
 
 // PulsarAdminClient define the client to call pulsar
 type PulsarAdminClient struct {
@@ -1211,15 +1216,31 @@ func (p *PulsarAdminClient) getBookieAffinityGroup(completeNSName string) (*util
 // applyBookieAffinityGroup moves the namespace's bookie affinity group towards the desired
 // state, writing only when it actually differs from what Pulsar reports.
 //
-// Setting, clearing and reading the affinity group all require superuser access in Pulsar
-// (NamespacesBase#internalSetBookieAffinityGroupAsync validates it, and the delete path is
-// implemented as a set of a null group). Reconciling unconditionally would therefore make
-// every namespace depend on superuser credentials, even ones that never use the feature,
-// so an unset-to-unset transition must not touch Pulsar at all.
+// Reading, setting and clearing the affinity group are all superuser-only in Pulsar
+// (internalGetBookieAffinityGroupAsync and internalSetBookieAffinityGroupAsync both call
+// validateSuperUserAccessAsync, and the delete path is implemented as a set of a null
+// group). A tenant-admin connection is therefore denied on every one of them, including
+// the read, on namespaces that never use the feature.
+//
+// So when no group is requested there is nothing to converge, and a denied read must not
+// fail the reconcile: that error would abort applyNamespacePolicies before every policy
+// that follows and leave the namespace short of Ready. The trade-off is that a group set
+// out of band is left in place rather than removed, which is why it is logged.
+//
+// A group that was explicitly requested is different: there the operator has been told to
+// write, and a permission failure has to surface rather than be silently skipped.
 func (p *PulsarAdminClient) applyBookieAffinityGroup(completeNSName string,
 	desired *v1alpha1.BookieAffinityGroupData) error {
 	current, err := p.getBookieAffinityGroup(completeNSName)
 	if err != nil {
+		if desired == nil && IsPermissionDenied(err) {
+			bookieAffinityLog.Info(
+				"Cannot read the bookie affinity group, and none is requested; leaving it as is. "+
+					"Reading it requires superuser access in Pulsar. If a group was set out of band "+
+					"it is retained, not removed.",
+				"namespace", completeNSName, "reason", ErrorReason(err))
+			return nil
+		}
 		return err
 	}
 

--- a/pkg/admin/impl.go
+++ b/pkg/admin/impl.go
@@ -1187,6 +1187,63 @@ func (p *PulsarAdminClient) RemoveTopicProperty(name string, persistent *bool, k
 	return nil
 }
 
+// getBookieAffinityGroup returns the bookie affinity group currently configured for the
+// namespace, or nil when none is set.
+//
+// Pulsar reports "no affinity group" in two different ways: a 404 ("Namespace
+// local-policies does not exist") when the namespace has no local policies at all, and a
+// 200 carrying an empty group when local policies exist but the affinity group was
+// cleared. Both are normalized to nil here.
+func (p *PulsarAdminClient) getBookieAffinityGroup(completeNSName string) (*utils.BookieAffinityGroupData, error) {
+	current, err := p.adminClient.Namespaces().GetBookieAffinityGroup(completeNSName)
+	if err != nil {
+		if IsNotFound(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	if current == nil || current.BookkeeperAffinityGroupPrimary == "" {
+		return nil, nil
+	}
+	return current, nil
+}
+
+// applyBookieAffinityGroup moves the namespace's bookie affinity group towards the desired
+// state, writing only when it actually differs from what Pulsar reports.
+//
+// Setting, clearing and reading the affinity group all require superuser access in Pulsar
+// (NamespacesBase#internalSetBookieAffinityGroupAsync validates it, and the delete path is
+// implemented as a set of a null group). Reconciling unconditionally would therefore make
+// every namespace depend on superuser credentials, even ones that never use the feature,
+// so an unset-to-unset transition must not touch Pulsar at all.
+func (p *PulsarAdminClient) applyBookieAffinityGroup(completeNSName string,
+	desired *v1alpha1.BookieAffinityGroupData) error {
+	current, err := p.getBookieAffinityGroup(completeNSName)
+	if err != nil {
+		return err
+	}
+
+	if desired == nil {
+		if current == nil {
+			return nil
+		}
+		if err := p.adminClient.Namespaces().DeleteBookieAffinityGroup(completeNSName); err != nil &&
+			!IsNotFound(err) {
+			return err
+		}
+		return nil
+	}
+
+	target := utils.BookieAffinityGroupData{
+		BookkeeperAffinityGroupPrimary:   desired.BookkeeperAffinityGroupPrimary,
+		BookkeeperAffinityGroupSecondary: desired.BookkeeperAffinityGroupSecondary,
+	}
+	if current != nil && *current == target {
+		return nil
+	}
+	return p.adminClient.Namespaces().SetBookieAffinityGroup(completeNSName, target)
+}
+
 func (p *PulsarAdminClient) applyNamespacePolicies(completeNSName string, params *NamespaceParams) error {
 	naName, err := utils.GetNamespaceName(completeNSName)
 	if err != nil {
@@ -1377,19 +1434,9 @@ func (p *PulsarAdminClient) applyNamespacePolicies(completeNSName string, params
 	// The pulsar-client-go library doesn't have DeletePersistence for namespaces,
 	// and sending empty PersistencePolicies{} with BookkeeperEnsemble=0 causes
 	// validation errors (Bookkeeper-Ensemble must be > 0 and <= 5).
-	if params.BookieAffinityGroup != nil {
-		err = p.adminClient.Namespaces().SetBookieAffinityGroup(completeNSName, utils.BookieAffinityGroupData{
-			BookkeeperAffinityGroupPrimary:   params.BookieAffinityGroup.BookkeeperAffinityGroupPrimary,
-			BookkeeperAffinityGroupSecondary: params.BookieAffinityGroup.BookkeeperAffinityGroupSecondary,
-		})
-		if err != nil {
-			return err
-		}
-	} else {
-		err = p.adminClient.Namespaces().DeleteBookieAffinityGroup(completeNSName)
-		if err != nil {
-			return err
-		}
+
+	if err := p.applyBookieAffinityGroup(completeNSName, params.BookieAffinityGroup); err != nil {
+		return err
 	}
 
 	// Handle topic auto-creation configuration

--- a/tests/operator/resources_test.go
+++ b/tests/operator/resources_test.go
@@ -1200,6 +1200,103 @@ var _ = Describe("Resources", func() {
 			})
 		})
 
+		Context("PulsarNamespace Bookie Affinity Group", Ordered, func() {
+			var (
+				bookieAffinityNamespace     *v1alphav1.PulsarNamespace
+				bookieAffinityNamespaceName string = "test-bookie-affinity-namespace"
+			)
+
+			BeforeAll(func() {
+				bookieAffinityNamespace = utils.MakePulsarNamespaceWithBookieAffinityGroup(
+					namespaceName,
+					bookieAffinityNamespaceName,
+					"cloud/bookie-affinity",
+					pconnName,
+					lifecyclePolicy,
+				)
+			})
+
+			It("should create namespace with bookie affinity group successfully", func() {
+				err := k8sClient.Create(ctx, bookieAffinityNamespace)
+				Expect(err == nil || apierrors.IsAlreadyExists(err)).Should(BeTrue())
+			})
+
+			It("should be ready", func() {
+				Eventually(func() bool {
+					ns := &v1alphav1.PulsarNamespace{}
+					tns := types.NamespacedName{Namespace: namespaceName, Name: bookieAffinityNamespaceName}
+					Expect(k8sClient.Get(ctx, tns, ns)).Should(Succeed())
+					return v1alphav1.IsPulsarResourceReady(ns)
+				}, "20s", "100ms").Should(BeTrue())
+			})
+
+			It("should have correct bookie affinity group configuration", func() {
+				ns := &v1alphav1.PulsarNamespace{}
+				tns := types.NamespacedName{Namespace: namespaceName, Name: bookieAffinityNamespaceName}
+				Expect(k8sClient.Get(ctx, tns, ns)).Should(Succeed())
+
+				Expect(ns.Spec.BookieAffinityGroup).ShouldNot(BeNil())
+				Expect(ns.Spec.BookieAffinityGroup.BookkeeperAffinityGroupPrimary).Should(Equal("group-primary"))
+				Expect(ns.Spec.BookieAffinityGroup.BookkeeperAffinityGroupSecondary).Should(Equal("group-secondary"))
+			})
+
+			It("should update the bookie affinity group successfully", func() {
+				ns := &v1alphav1.PulsarNamespace{}
+				tns := types.NamespacedName{Namespace: namespaceName, Name: bookieAffinityNamespaceName}
+				Expect(k8sClient.Get(ctx, tns, ns)).Should(Succeed())
+
+				ns.Spec.BookieAffinityGroup.BookkeeperAffinityGroupPrimary = "group-primary-updated"
+				ns.Spec.BookieAffinityGroup.BookkeeperAffinityGroupSecondary = ""
+				Expect(k8sClient.Update(ctx, ns)).Should(Succeed())
+			})
+
+			It("should be ready after update", func() {
+				Eventually(func() bool {
+					ns := &v1alphav1.PulsarNamespace{}
+					tns := types.NamespacedName{Namespace: namespaceName, Name: bookieAffinityNamespaceName}
+					Expect(k8sClient.Get(ctx, tns, ns)).Should(Succeed())
+					return v1alphav1.IsPulsarResourceReady(ns) &&
+						ns.Status.ObservedGeneration == ns.Generation
+				}, "20s", "100ms").Should(BeTrue())
+			})
+
+			It("should reject an empty primary affinity group", func() {
+				ns := &v1alphav1.PulsarNamespace{}
+				tns := types.NamespacedName{Namespace: namespaceName, Name: bookieAffinityNamespaceName}
+				Expect(k8sClient.Get(ctx, tns, ns)).Should(Succeed())
+
+				ns.Spec.BookieAffinityGroup.BookkeeperAffinityGroupPrimary = ""
+				Expect(k8sClient.Update(ctx, ns)).ShouldNot(Succeed())
+			})
+
+			It("should remove the affinity policy when the field is dropped", func() {
+				ns := &v1alphav1.PulsarNamespace{}
+				tns := types.NamespacedName{Namespace: namespaceName, Name: bookieAffinityNamespaceName}
+				Expect(k8sClient.Get(ctx, tns, ns)).Should(Succeed())
+
+				ns.Spec.BookieAffinityGroup = nil
+				Expect(k8sClient.Update(ctx, ns)).Should(Succeed())
+
+				Eventually(func() bool {
+					ns := &v1alphav1.PulsarNamespace{}
+					Expect(k8sClient.Get(ctx, tns, ns)).Should(Succeed())
+					return v1alphav1.IsPulsarResourceReady(ns) &&
+						ns.Status.ObservedGeneration == ns.Generation
+				}, "20s", "100ms").Should(BeTrue())
+			})
+
+			AfterAll(func() {
+				if bookieAffinityNamespace != nil {
+					Eventually(func(g Gomega) {
+						ns := &v1alphav1.PulsarNamespace{}
+						tns := types.NamespacedName{Namespace: namespaceName, Name: bookieAffinityNamespaceName}
+						g.Expect(k8sClient.Get(ctx, tns, ns)).Should(Succeed())
+						g.Expect(k8sClient.Delete(ctx, ns)).Should(Succeed())
+					}).Should(Succeed())
+				}
+			})
+		})
+
 		Context("PulsarTopic Auto Subscription Creation", Ordered, func() {
 			var (
 				autoSubscriptionTopic     *v1alphav1.PulsarTopic

--- a/tests/utils/spec.go
+++ b/tests/utils/spec.go
@@ -112,6 +112,17 @@ func MakePulsarNamespaceWithOffloadPolicies(namespace, name, namespaceName, conn
 	return ns
 }
 
+// MakePulsarNamespaceWithBookieAffinityGroup will generate a PulsarNamespace pinned to a
+// pair of BookKeeper affinity groups
+func MakePulsarNamespaceWithBookieAffinityGroup(namespace, name, namespaceName, connectionName string, policy v1alpha1.PulsarResourceLifeCyclePolicy) *v1alpha1.PulsarNamespace {
+	ns := MakePulsarNamespace(namespace, name, namespaceName, connectionName, policy)
+	ns.Spec.BookieAffinityGroup = &v1alpha1.BookieAffinityGroupData{
+		BookkeeperAffinityGroupPrimary:   "group-primary",
+		BookkeeperAffinityGroupSecondary: "group-secondary",
+	}
+	return ns
+}
+
 // MakePulsarNamespaceWithRateLimiting will generate a PulsarNamespace with rate limiting configurations
 func MakePulsarNamespaceWithRateLimiting(namespace, name, namespaceName, connectionName string, policy v1alpha1.PulsarResourceLifeCyclePolicy) *v1alpha1.PulsarNamespace {
 	backlogSize := resource.MustParse("5Gi")


### PR DESCRIPTION
Fixes #420.

`spec.bookieAffinityGroup` already existed on `PulsarNamespace` and was already reconciled, so this is not a new feature — it is a fix to the reconcile path, plus the validation and docs the field was missing. Rationale for the reframing is in [this issue comment](https://github.com/streamnative/pulsar-resources-operator/issues/420#issuecomment-5298443344).

## The bug

Every `PulsarNamespace` that did **not** declare `bookieAffinityGroup` issued an unconditional `DELETE .../persistence/bookieAffinity` on each reconcile, with no `IsNotFound` tolerance — unlike the neighbouring `RemoveTopicAutoCreation` and `RemoveInactiveTopicPolicies` branches in the same function:

```go
} else {
    err = p.adminClient.Namespaces().DeleteBookieAffinityGroup(completeNSName)
    if err != nil {
        return err
    }
}
```

Pulsar implements that delete as a set of a null group (`NamespacesBase#internalDeleteBookieAffinityGroupAsync` → `internalSetBookieAffinityGroupAsync(null)`), and both the setter and the getter call `validateSuperUserAccessAsync()`. Consequences:

1. **A tenant-admin connection cannot reconcile any namespace.** It gets 401/403 on that DELETE, `ApplyNamespace` fails, and the namespace never reaches `Ready` — for users who never touched bookie affinity at all.
2. **Spurious metadata writes.** `setLocalPoliciesWithCreate` creates the local-policies znode with default bundle data even when there was nothing to delete.
3. No read of current state, so "removing the setting removes the policy" was assumed rather than verified.

## The fix

`applyBookieAffinityGroup` reads the current group first and writes only on an actual diff. Both of Pulsar's "no group" answers are normalized to nil: a 404 `"Namespace local-policies does not exist"` when the namespace has no local policies, and a 200 carrying an empty group when they were cleared.

Reading is superuser-gated too (`internalGetBookieAffinityGroupAsync` calls `validateSuperUserAccessAsync`, same as the setter), so read-before-write on its own does **not** lift the superuser requirement — it just moves it from a DELETE to a GET. A tenant-admin connection is denied either way, and the error still aborts `applyNamespacePolicies` before every policy that follows.

So the denial is handled explicitly, split by intent:

- **No group requested** (`bookieAffinityGroup` absent) — there is nothing to converge, so a 401/403 on the read is logged and skipped rather than failed. This is what actually unblocks reconcile for namespaces that never use the feature. The trade-off is that a group set out of band is retained rather than removed; the log says so.
- **A group requested** — the operator has been told to write, so a permission failure surfaces. Silently skipping it would leave the CR claiming a configuration Pulsar never received.

Any other read failure still propagates rather than being mistaken for "unset".

The 401/403 test is `IsPermissionDenied(err)`, a new helper in `pkg/admin/errors.go`. `ReasonUnauthorized` and `ReasonForbidden` were already declared there but had no consumers anywhere in the repo; this is the first.

## Also in this PR

- **Corrected the `BookieAffinityGroup` godoc.** It read *"is the name of the namespace isolation policy to apply to the namespace"*, which describes `PulsarNSIsolationPolicy` — a different feature. That wording is why #420 was filed as "not exposed through any CRD".
- **`MinLength=1` on both group names.** An empty primary passed CRD validation and was pushed to Pulsar, where `BookieRackAffinityMapping` cannot place ledgers. Only `""` becomes invalid, so no working configuration is rejected.
- **Documented the end-to-end carve-out** — new "Broker and Bookie Isolation" section in `docs/pulsar_namespace.md` pairing `PulsarNSIsolationPolicy` (brokers) with `bookieAffinityGroup` (bookies), including the rack-metadata prerequisite and the superuser requirement. Cross-linked from `docs/pulsar_ns_isolation_policy.md`.

## Tests

- `pkg/admin/bookie_affinity_group_test.go` — 7 table cases over an `httptest` server in the style of `namespace_backlog_quota_test.go`: unset stays unset without writing, cleared group is not deleted again, removal deletes, set when absent, matching group left alone, changed group rewritten, dropped secondary rewritten. Plus read-failure propagation.
- `tests/operator/resources_test.go` — a `PulsarNamespace Bookie Affinity Group` context covering create → update → empty-primary rejection → field removal, mirroring the offload-policies coverage from #413.
- `pkg/admin/bookie_affinity_group_test.go` — the permission cases from @freeznet's review, driven through `applyNamespacePolicies` rather than the helper in isolation, because the combination that broke is "field omitted" *and* "read denied": affinity endpoint returns 401/403 with no group requested → no error and a later policy still applied; the same denial with a group requested → still fails, and the reconcile does not continue past a write it could not make. Both tolerance cases fail on the previous head of this branch.
- `pkg/admin/errors_test.go` — `IsPermissionDenied` across 401/403/404/500, wrapped and pointer `rest.Error`, and non-REST errors.

Verified: `go build ./...`, `go test ./pkg/... ./api/...` (including the existing `applyNamespacePolicies` backlog-quota tests, which now traverse the new read path), `make fmt vet`, `make license-check` (479 files, 0 invalid). E2E not executed — needs a live cluster via `ADMIN_SERVICE_URL`.

## Note for reviewers

**The CRD schema was updated by hand, deliberately.** `make manifests` pulls controller-gen v0.17.0 (pinned at `Makefile:201`) but the committed CRDs were generated with v0.15.0. Running it rewrites all 19 CRDs — ~1300 lines of unrelated churn — and strips the Apache license header from every YAML. Only the `bookieAffinityGroup` block was applied here, byte-matching the generator's output. **The Makefile/CRD version skew is pre-existing and wants its own PR.**

The sn-operator half of #420 (declarative bookie-to-isolation-group membership on `BookKeeperCluster`) is a genuinely separate gap and belongs on that repo — nothing here can express it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

