### PR TITLE
fix(admin): tolerate unauthorized implicit bookie affinity cleanup

### DIFF
--- a/docs/pulsar_namespace.md
+++ b/docs/pulsar_namespace.md
@@ -51,6 +51,12 @@ The `PulsarNamespace` resource defines a namespace in a Pulsar cluster. It allow
 
 Note: Valid time units are "s" (seconds), "m" (minutes), "h" (hours), "d" (days), "w" (weeks).
 
+Setting `bookieAffinityGroup` requires Pulsar superuser access. When the field is omitted,
+the operator attempts to clear the existing group. If that deletion returns HTTP 401 or 403,
+the operator logs the skipped deletion and continues applying other namespace policies;
+any existing affinity group is retained. Other deletion errors and failures to set an
+explicitly configured group still fail reconciliation.
+
 ## Backlog Quota Selection
 
 `backlogQuotaRetentionPolicy` is required whenever a backlog quota is configured. `backlogQuotaType` selects which limit the operator sends to Pulsar:

--- a/pkg/admin/impl.go
+++ b/pkg/admin/impl.go
@@ -26,6 +26,7 @@ import (
 	"github.com/apache/pulsar-client-go/pulsaradmin/pkg/utils"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	"github.com/streamnative/pulsar-resources-operator/api/v1alpha1"
 	rutils "github.com/streamnative/pulsar-resources-operator/pkg/utils"
@@ -1388,7 +1389,16 @@ func (p *PulsarAdminClient) applyNamespacePolicies(completeNSName string, params
 	} else {
 		err = p.adminClient.Namespaces().DeleteBookieAffinityGroup(completeNSName)
 		if err != nil {
-			return err
+			// Clearing an omitted policy requires superuser access, even when no group exists.
+			// Tenant admins must still be able to apply the remaining namespace policies.
+			switch ErrorReason(err) {
+			case ReasonUnauthorized, ReasonForbidden:
+				log.Log.WithName("pulsar-admin").Info(
+					"Skipping bookie affinity group deletion: insufficient permissions; any existing group is retained",
+					"namespace", completeNSName, "error", err)
+			default:
+				return err
+			}
 		}
 	}
 

--- a/pkg/admin/namespace_bookie_affinity_test.go
+++ b/pkg/admin/namespace_bookie_affinity_test.go
@@ -1,0 +1,95 @@
+// Copyright 2026 StreamNative
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package admin
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	pulsaradmin "github.com/apache/pulsar-client-go/pulsaradmin/pkg/admin"
+	"github.com/apache/pulsar-client-go/pulsaradmin/pkg/admin/config"
+	"k8s.io/utils/ptr"
+
+	"github.com/streamnative/pulsar-resources-operator/api/v1alpha1"
+)
+
+func TestApplyNamespacePoliciesBookieAffinityPermissions(t *testing.T) {
+	for _, tt := range []struct {
+		name     string
+		explicit bool
+		status   int
+		wantErr  bool
+	}{
+		{name: "delete succeeds", status: http.StatusNoContent},
+		{name: "delete unauthorized continues", status: http.StatusUnauthorized},
+		{name: "delete forbidden continues", status: http.StatusForbidden},
+		{name: "delete server failure propagates", status: http.StatusInternalServerError, wantErr: true},
+		{name: "delete not found propagates", status: http.StatusNotFound, wantErr: true},
+		{name: "set succeeds", explicit: true, status: http.StatusNoContent},
+		{name: "set unauthorized propagates", explicit: true, status: http.StatusUnauthorized, wantErr: true},
+		{name: "set forbidden propagates", explicit: true, status: http.StatusForbidden, wantErr: true},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			var affinityCalled, subsequentPolicyCalled bool
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				switch r.URL.Path {
+				case "/admin/v2/namespaces/public/default/persistence/bookieAffinity":
+					affinityCalled = true
+					wantMethod := http.MethodDelete
+					if tt.explicit {
+						wantMethod = http.MethodPost
+					}
+					if r.Method != wantMethod {
+						t.Errorf("affinity method = %s, want %s", r.Method, wantMethod)
+					}
+					if tt.status != http.StatusNoContent {
+						http.Error(w, "policy operation failed", tt.status)
+						return
+					}
+				case "/admin/v2/namespaces/public/default/schemaValidationEnforced":
+					subsequentPolicyCalled = true
+					if !affinityCalled {
+						t.Error("subsequent policy applied before affinity operation")
+					}
+				}
+				w.WriteHeader(http.StatusNoContent)
+			}))
+			defer server.Close()
+			client, err := pulsaradmin.New(&config.Config{WebServiceURL: server.URL})
+			if err != nil {
+				t.Fatalf("create admin client: %v", err)
+			}
+			params := &NamespaceParams{SchemaValidationEnforced: ptr.To(true)}
+			if tt.explicit {
+				params.BookieAffinityGroup = &v1alpha1.BookieAffinityGroupData{BookkeeperAffinityGroupPrimary: "primary"}
+			}
+			adminClient := &PulsarAdminClient{adminClient: client}
+			err = adminClient.applyNamespacePolicies("public/default", params)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("apply policies error = %v, want error %v", err, tt.wantErr)
+			}
+			if tt.wantErr && ErrorReason(err) != Reason(tt.status) {
+				t.Errorf("error reason = %v, want %v", ErrorReason(err), tt.status)
+			}
+			if !affinityCalled {
+				t.Error("affinity operation was not called")
+			}
+			if subsequentPolicyCalled == tt.wantErr {
+				t.Errorf("subsequent policy called = %v, want %v", subsequentPolicyCalled, !tt.wantErr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
### Motivation

When `PulsarNamespace.spec.bookieAffinityGroup` is omitted, reconciliation implicitly deletes the namespace's bookie affinity group. Pulsar requires superuser access for this operation even if no group exists, so a tenant admin can create the namespace but fail to apply subsequent namespace policies.

### Modifications

- Continue applying namespace policies when implicit bookie affinity deletion returns HTTP 401 or 403, logging that any existing group is retained.
- Preserve failures for explicitly configured affinity groups and all other deletion errors.
- Document the permission requirements and retained-policy behavior.

### Verifying this change

Added eight HTTP-backed regression cases covering successful deletion and setting, both permission error codes, other deletion failures, and whether the subsequent schema validation policy is applied.

Passed locally with Go 1.25.11:
- `make test` (including controller envtest)
- `go test ./pkg/admin -race -run TestApplyNamespacePoliciesBookieAffinityPermissions -count=1`
- `./scripts/lint.sh ./...` (0 issues)
- Pre-commit license, lint, formatting, and vet checks

A live Pulsar cluster with tenant-admin credentials was not exercised.

### Documentation

- [x] `doc` — Updated namespace documentation.
